### PR TITLE
Refactor CLI commands to require PORTAL_URL environment variable

### DIFF
--- a/apps/cli/gitmap/commands/clone.py
+++ b/apps/cli/gitmap/commands/clone.py
@@ -26,6 +26,8 @@ from gitmap_core.maps import get_webmap_by_id
 from gitmap_core.models import Remote
 from gitmap_core.repository import Repository
 
+from .utils import get_portal_url
+
 console = Console()
 
 
@@ -46,8 +48,8 @@ console = Console()
 @click.option(
     "--url",
     "-u",
-    default="https://www.arcgis.com",
-    help="Portal URL (defaults to ArcGIS Online).",
+    default="",
+    help="Portal URL (or use PORTAL_URL env var, which is required).",
 )
 @click.option(
     "--username",
@@ -71,9 +73,12 @@ def clone(
         gitmap clone abc123def456 --url https://portal.example.com
     """
     try:
+        # Get Portal URL from parameter or environment variable
+        portal_url = get_portal_url(url if url else None)
+        
         # Connect to Portal
-        console.print(f"[dim]Connecting to {url}...[/dim]")
-        connection = get_connection(url=url, username=username if username else None)
+        console.print(f"[dim]Connecting to {portal_url}...[/dim]")
+        connection = get_connection(url=portal_url, username=username if username else None)
 
         if connection.username:
             console.print(f"[dim]Authenticated as {connection.username}[/dim]")
@@ -110,7 +115,7 @@ def clone(
         config = repo.get_config()
         config.remote = Remote(
             name="origin",
-            url=url,
+            url=portal_url,
             item_id=item_id,
         )
         repo.update_config(config)

--- a/apps/cli/gitmap/commands/layer-settings-merge.py
+++ b/apps/cli/gitmap/commands/layer-settings-merge.py
@@ -36,6 +36,8 @@ from gitmap_core.repository import Repository
 from gitmap_core.repository import find_repository
 from gitmap_core.repository import init_repository
 
+from .utils import get_portal_url
+
 console = Console()
 
 
@@ -193,12 +195,15 @@ def _resolve_source_map(
         console.print(f"[dim]No repository found for item {source}[/dim]")
         console.print("[dim]Cloning map from Portal...[/dim]")
 
-        # Get Portal connection from current repo or use defaults
-        portal_url = "https://www.arcgis.com"
+        # Get Portal connection from current repo or environment variable
+        portal_url = None
         if current_repo:
             config = current_repo.get_config()
-            if config.remote:
+            if config.remote and config.remote.url:
                 portal_url = config.remote.url
+        
+        # Get from environment variable if not in repo config
+        portal_url = get_portal_url(portal_url)
 
         connection = get_connection(url=portal_url)
         item, map_data = get_webmap_by_id(connection.gis, source)
@@ -347,10 +352,14 @@ def _resolve_target_map(
     # Check if it's an item ID
     if _is_item_id(target):
         # For target, we'll fetch from Portal directly
-        portal_url = "https://www.arcgis.com"
-        config = current_repo.get_config()
-        if config.remote:
-            portal_url = config.remote.url
+        portal_url = None
+        if current_repo:
+            config = current_repo.get_config()
+            if config.remote and config.remote.url:
+                portal_url = config.remote.url
+        
+        # Get from environment variable if not in repo config
+        portal_url = get_portal_url(portal_url)
 
         connection = get_connection(url=portal_url)
         item, map_data = get_webmap_by_id(connection.gis, target)
@@ -708,13 +717,15 @@ def _render_summary(
 def _get_portal_url(
         current_repo: Repository | None,
 ) -> str:
-    """Get Portal URL from repo config or default."""
-    portal_url = "https://www.arcgis.com"
+    """Get Portal URL from repo config or environment variable."""
+    portal_url = None
     if current_repo:
         config = current_repo.get_config()
         if config.remote and config.remote.url:
             portal_url = config.remote.url
-    return portal_url
+    
+    # Get from environment variable if not in repo config
+    return get_portal_url(portal_url)
 
 
 def _get_or_clone_repo_for_item(
@@ -1119,13 +1130,16 @@ def _transfer_to_local_folder(
                 default="yes",
             ) == "yes":
                 console.print()
-                # Get portal URL from first repo with remote, or use default
-                portal_url = "https://www.arcgis.com"
+                # Get portal URL from first repo with remote, or environment variable
+                portal_url = None
                 for repo, _ in repos_with_remotes:
                     config = repo.get_config()
                     if config.remote and config.remote.url:
                         portal_url = config.remote.url
                         break
+                
+                # Get from environment variable if not in repo config
+                portal_url = get_portal_url(portal_url)
                 connection = get_connection(url=portal_url)
                 
                 for repo, repo_name in repos_with_remotes:

--- a/apps/cli/gitmap/commands/list.py
+++ b/apps/cli/gitmap/commands/list.py
@@ -27,6 +27,8 @@ from rich.table import Table
 from gitmap_core.connection import get_connection
 from gitmap_core.maps import list_webmaps
 
+from .utils import get_portal_url
+
 console = Console()
 
 
@@ -63,7 +65,7 @@ console = Console()
     "--url",
     "-u",
     default="",
-    help="Portal URL (or use PORTAL_URL env var, defaults to ArcGIS Online).",
+    help="Portal URL (or use PORTAL_URL env var, which is required).",
 )
 @click.option(
     "--username",
@@ -96,8 +98,8 @@ def list_maps(
         gitmap list --query "title:MyMap"
     """
     try:
-        # Determine portal URL (from option, env var, or default)
-        portal_url = url or os.environ.get("PORTAL_URL", "https://www.arcgis.com")
+        # Get Portal URL from parameter or environment variable
+        portal_url = get_portal_url(url if url else None)
         
         # Connect to Portal/AGOL
         console.print(f"[dim]Connecting to {portal_url}...[/dim]")

--- a/apps/cli/gitmap/commands/notify.py
+++ b/apps/cli/gitmap/commands/notify.py
@@ -32,6 +32,8 @@ from gitmap_core.communication import list_groups
 from gitmap_core.communication import send_group_notification
 from gitmap_core.connection import get_connection
 
+from .utils import get_portal_url
+
 console = Console()
 
 
@@ -78,7 +80,7 @@ console = Console()
     "--url",
     "-u",
     default="",
-    help="Portal URL (or use PORTAL_URL env var, defaults to ArcGIS Online).",
+    help="Portal URL (or use PORTAL_URL env var, which is required).",
 )
 @click.option(
     "--username",
@@ -111,8 +113,8 @@ def notify(
     # Handle list groups mode
     if list_groups_flag:
         try:
-            # Determine portal URL (from option, env var, or default)
-            portal_url = url or os.environ.get("PORTAL_URL", "https://www.arcgis.com")
+            # Get Portal URL from parameter or environment variable
+            portal_url = get_portal_url(url if url else None)
             
             # Connect to Portal/AGOL
             console.print(f"[dim]Connecting to {portal_url}...[/dim]")
@@ -163,8 +165,8 @@ def notify(
         if not body:
             raise click.ClickException("Notification body is required (use --message or --message-file).")
 
-        # Determine portal URL (from option, env var, or default)
-        portal_url = url or os.environ.get("PORTAL_URL", "https://www.arcgis.com")
+        # Get Portal URL from parameter or environment variable
+        portal_url = get_portal_url(url if url else None)
         
         # Connect to Portal/AGOL
         console.print(f"[dim]Connecting to {portal_url}...[/dim]")

--- a/apps/cli/gitmap/commands/pull.py
+++ b/apps/cli/gitmap/commands/pull.py
@@ -23,6 +23,8 @@ from gitmap_core.connection import get_connection
 from gitmap_core.remote import RemoteOperations
 from gitmap_core.repository import find_repository
 
+from .utils import get_portal_url
+
 console = Console()
 
 
@@ -70,10 +72,15 @@ def pull(
 
         # Determine Portal URL
         config = repo.get_config()
-        if not config.remote:
-            raise click.ClickException("No remote configured. Use 'gitmap clone' or configure a remote.")
-
-        portal_url = url or config.remote.url
+        if url:
+            # Use provided URL
+            portal_url = url
+        elif config.remote and config.remote.url:
+            # Use configured remote URL
+            portal_url = config.remote.url
+        else:
+            # Get from environment variable (required)
+            portal_url = get_portal_url()
 
         # Connect to Portal
         console.print(f"[dim]Connecting to {portal_url}...[/dim]")

--- a/apps/cli/gitmap/commands/push.py
+++ b/apps/cli/gitmap/commands/push.py
@@ -23,6 +23,8 @@ from gitmap_core.connection import get_connection
 from gitmap_core.remote import RemoteOperations
 from gitmap_core.repository import find_repository
 
+from .utils import get_portal_url
+
 console = Console()
 
 
@@ -81,7 +83,15 @@ def push(
 
         # Determine Portal URL
         config = repo.get_config()
-        portal_url = url or (config.remote.url if config.remote else "https://www.arcgis.com")
+        if url:
+            # Use provided URL
+            portal_url = url
+        elif config.remote and config.remote.url:
+            # Use configured remote URL
+            portal_url = config.remote.url
+        else:
+            # Get from environment variable (required)
+            portal_url = get_portal_url()
 
         # Connect to Portal
         console.print(f"[dim]Connecting to {portal_url}...[/dim]")

--- a/apps/cli/gitmap/commands/utils.py
+++ b/apps/cli/gitmap/commands/utils.py
@@ -1,0 +1,46 @@
+"""Utility functions for GitMap CLI commands.
+
+Execution Context:
+    CLI command utilities - imported by command modules
+
+Dependencies:
+    - os: Environment variable access
+
+Metadata:
+    Version: 0.1.0
+    Author: GitMap Team
+"""
+from __future__ import annotations
+
+import os
+
+
+def get_portal_url(url: str | None = None) -> str:
+    """Get Portal URL from parameter or environment variable.
+    
+    Portal URL MUST be provided either as a parameter or via PORTAL_URL
+    environment variable. No default fallback to arcgis.com is provided.
+    
+    Args:
+        url: Optional Portal URL parameter (takes precedence if provided).
+    
+    Returns:
+        Portal URL string.
+    
+    Raises:
+        ValueError: If neither url parameter nor PORTAL_URL env var is set.
+    """
+    # If URL is explicitly provided, use it
+    if url:
+        return url
+    
+    # Otherwise, require PORTAL_URL environment variable
+    portal_url = os.getenv("PORTAL_URL")
+    if not portal_url:
+        raise ValueError(
+            "Portal URL is required. Set PORTAL_URL environment variable "
+            "in your .env file or provide --url parameter."
+        )
+    
+    return portal_url
+


### PR DESCRIPTION
- Created utils.py with get_portal_url() function that requires PORTAL_URL env var
- Updated clone.py to require PORTAL_URL instead of defaulting to arcgis.com
- Updated push.py to require PORTAL_URL instead of defaulting to arcgis.com
- Updated pull.py to support PORTAL_URL as fallback (consistent with push)
- Updated notify.py to require PORTAL_URL in both list-groups and notification modes
- Updated list.py to require PORTAL_URL instead of defaulting to arcgis.com
- Updated layer-settings-merge.py to use get_portal_url() in 4 locations

This ensures CLI commands match MCP tools behavior and prevent unintended connections to ArcGIS Online.