### PR TITLE
Add data directory to .gitignore and enhance RemoteOperations for main branch item retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,7 @@ logs/
 *.temp
 .cache/
 
+#data directories
+data/ 
+
 


### PR DESCRIPTION
- Updated .gitignore to include 'data/' directory
- Enhanced RemoteOperations class to directly pull data from the original item_id for the main branch, updating local index and remote tracking reference as needed