### PR TITLE
docs: add MIT license and update release notes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 GitMap Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/documentation/project_specs/20-operations/release_notes.md
+++ b/documentation/project_specs/20-operations/release_notes.md
@@ -15,6 +15,7 @@
 | gitmap_core    | 0.4.0   | `packages/gitmap_core/pyproject.toml`    |
 | gitmap-mcp     | 0.2.0   | `apps/mcp/gitmap-mcp/pyproject.toml`     |
 | gitmap-gui     | 0.1.0   | `apps/client/gitmap-gui/pyproject.toml`  |
+| gitmap-client  | 0.1.0   | `apps/client/gitmap-client/pyproject.toml` |
 
 ## Releases
 
@@ -31,6 +32,13 @@
 - Updated summary messages to provide guidance based on auto-commit status
 - Maintains backward compatibility with auto-commit disabled by default
 - Updated `gitmap-cli` documentation with auto-commit feature usage examples
+- Added auto-pull daemon with interval-based scheduling for automated synchronization
+
+**TUI Client (gitmap-client):**
+- New Terminal UI client built with Textual framework
+- Repository selection and management interface
+- Improved commit history display with branch visualization
+- Interactive navigation for GitMap operations
 
 **Web GUI (gitmap-gui):**
 - Major refactoring: Modularized frontend architecture for improved maintainability
@@ -49,6 +57,12 @@
 - Added comprehensive API endpoint documentation organized by feature category
 - Improved error handling and debugging information in API responses
 - Reduced main `app.py` from ~2900 lines to ~100 lines for better maintainability
+- Reorganized navigation structure for improved usability
+- Added LSM (Layer Settings Merge) health check functionality
+
+**Documentation:**
+- Added CLAUDE.md project guide for AI assistants (Claude Code, Cursor, etc.)
+- MIT License added to repository
 
 ### [release/1.4.2]
 


### PR DESCRIPTION
Add MIT license file and update release notes for v2.0.0 with recent
features including TUI client, auto-pull daemon, GUI enhancements,
and documentation additions.