### PR TITLE
docs: overhaul README onboarding

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -61,6 +61,14 @@ Packages to configure:
 
 ## Publishing a New Release
 
+Before tagging, run the local release guardrail:
+
+```bash
+python3 scripts/release_checks.py
+```
+
+This verifies that the published package versions, dependency pins, project metadata, and publish workflow tag patterns are still aligned.
+
 ### Patch release (core fix)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -8,675 +8,268 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Tests](https://img.shields.io/badge/tests-734%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
-GitMap brings Git-like version control to ArcGIS Online and Enterprise Portal web maps. Branch, commit, diff, merge, push, and pull maps using workflows your team already knows.
+GitMap brings Git-style branching, history, diffs, merges, and rollbacks to ArcGIS Online and Portal web maps.
 
-```
-$ gitmap commit -m "Added flood risk layer"
-[main a3f9c12] Added flood risk layer
- 1 layer changed
-
-$ gitmap diff --branch main
-~ Layer: Parcels
-  opacity: 0.8 → 1.0
-  visible: false → true
-
-$ gitmap merge feature/new-basemap
-Merged feature/new-basemap into main
+```bash
+$ gitmap clone abc123def456 FloodRiskMap
+$ cd FloodRiskMap
+$ gitmap branch feature/dark-basemap
+$ gitmap checkout feature/dark-basemap
+$ gitmap pull
+$ gitmap diff main feature/dark-basemap --format visual
+$ gitmap commit -m "Switch to dark basemap"
+$ gitmap checkout main && gitmap merge feature/dark-basemap && gitmap push
 ```
 
----
+## Why teams use GitMap
 
-## Why GitMap?
+- **Track every map change** with commit history instead of guessing who changed what.
+- **Experiment safely** on branches before touching production maps.
+- **Review diffs clearly** at the layer and property level.
+- **Roll back fast** when a bad basemap, renderer, popup, or visibility change slips through.
+- **Scale beyond one map** with bulk repo setup, auto-pull, and Portal-aware workflows.
 
-| Problem | GitMap Solution |
-|---|---|
-| "Who changed the basemap last Tuesday?" | `gitmap log` — full commit history with author + timestamp |
-| "Can I test this symbology without breaking prod?" | `gitmap branch feature/symbology` — isolated branches |
-| "Revert to last week's version" | `gitmap checkout <commit-id>` |
-| "What's different between staging and production?" | `gitmap diff --branch production` |
-| "Keep 50 maps in sync with Portal" | `gitmap auto-pull` |
+## What GitMap gives you
 
----
+- **Git-like CLI for GIS** — `init`, `clone`, `status`, `commit`, `branch`, `checkout`, `diff`, `log`, `merge`, `push`, `pull`, `revert`, and more
+- **ArcGIS-aware diffing** — layer/table additions, removals, and field-level JSON changes
+- **Three-way merge support** — branch and merge map changes without manual JSON surgery
+- **Shareable outputs** — terminal, visual, JSON, and HTML diff/report formats
+- **Automation hooks** — bulk repo setup, auto-pull, context graph exports, and MCP support for AI workflows
+- **Cross-platform Python package** — macOS, Linux, and Windows on Python 3.11-3.14
 
-## Table of Contents
+## Install in one step
 
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Configuration](#configuration)
-- [CLI Commands](#cli-commands)
-- [Usage Examples](#usage-examples)
-- [Docker Setup](#docker-setup)
-- [Development](#development)
-- [Architecture](#architecture)
-
----
-
-## Installation
-
-### Prerequisites
-
-- Python 3.11, 3.12, 3.13, or 3.14
-- ArcGIS Portal or ArcGIS Online account
-
-### Install from PyPI (Recommended)
+### Recommended: PyPI
 
 ```bash
 pip install gitmap
 ```
 
-That's it. The `gitmap` command is now available in your terminal.
+Verify it worked:
 
-### Install from Source
+```bash
+gitmap --version
+```
+
+### From source
 
 ```bash
 git clone https://github.com/14-TR/Git-Map.git
 cd Git-Map
-
-# Install core library + CLI
 pip install -e packages/gitmap_core
 pip install -e apps/cli/gitmap
 ```
 
-### Verify Installation
+## Quickstart: first successful workflow
+
+### 1. Set ArcGIS credentials
 
 ```bash
-gitmap --version
-# gitmap, version 0.7.0
+export PORTAL_URL=https://your-org.maps.arcgis.com
+export ARCGIS_USERNAME=your_username
+export ARCGIS_PASSWORD=your_password
 ```
 
----
-
-## Quick Start
-
-### 1. Configure Authentication
+Or copy the example environment file and edit it:
 
 ```bash
 cp configs/env.example .env
 ```
 
-Edit `.env`:
-
-```env
-PORTAL_URL=https://your-org.maps.arcgis.com
-PORTAL_USER=your_username
-PORTAL_PASSWORD=your_password
-```
-
-> **Note:** `.env` is git-ignored and never committed.
-
-### 2. Initialize a Repository
-
-```bash
-gitmap init --project-name "Flood Risk Map"
-```
-
-### 3. Clone an Existing Map from Portal
+### 2. Clone a web map from ArcGIS
 
 ```bash
 gitmap clone abc123def456
+cd YourMapTitle
 ```
 
-### 4. Create a Branch, Edit, Commit
+`abc123def456` is the web map item ID from ArcGIS Online or Portal.
+
+### 3. Confirm the repo is clean
 
 ```bash
-gitmap branch feature/new-layer
-gitmap checkout feature/new-layer
-
-# Edit your map JSON files...
-
 gitmap status
-gitmap commit -m "Added hydrology layer"
 ```
 
-### 5. Push Back to Portal
+Typical output:
+
+```text
+╭─ GitMap Status ─╮
+│ On branch: main │
+╰─────────────────╯
+Nothing to commit, working tree clean
+```
+
+### 4. Create a feature branch
 
 ```bash
-gitmap push
+gitmap branch feature/new-basemap
+gitmap checkout feature/new-basemap
 ```
 
-### 6. Merge When Ready
+### 5. Make a change and pull it locally
+
+Edit the map in ArcGIS, then sync the latest state into your branch:
+
+```bash
+gitmap pull
+gitmap status
+```
+
+### 6. Review exactly what changed
+
+```bash
+gitmap diff main feature/new-basemap --format visual
+```
+
+For a shareable stakeholder report:
+
+```bash
+gitmap diff main feature/new-basemap --format html --output basemap-review.html
+```
+
+### 7. Commit the branch
+
+```bash
+gitmap commit -m "Switch to dark basemap"
+```
+
+### 8. Merge and deploy
 
 ```bash
 gitmap checkout main
-gitmap merge feature/new-layer
+gitmap merge feature/new-basemap
 gitmap push
 ```
 
----
+That is the core GitMap loop: **clone → branch → pull → diff → commit → merge → push**.
+
+## Demo workflows
+
+### Branch and compare map changes
+
+```bash
+gitmap branch feature/parcel-popup
+gitmap checkout feature/parcel-popup
+gitmap pull
+gitmap diff main feature/parcel-popup --verbose
+```
+
+### Inspect history like Git
+
+```bash
+gitmap log --graph --oneline
+gitmap show HEAD
+```
+
+### Revert a bad deployment safely
+
+```bash
+gitmap log --oneline
+gitmap revert a3f2c1b0
+gitmap push
+```
+
+### Manage many maps at once
+
+```bash
+gitmap setup-repos --owner myusername --directory repositories
+gitmap auto-pull --directory repositories --auto-commit
+```
+
+## Common commands
+
+| Command | What it does |
+|---|---|
+| `gitmap clone <ITEM_ID> [PATH]` | Create a local repo from an ArcGIS web map |
+| `gitmap status` | Show branch and working tree state |
+| `gitmap branch <NAME>` | Create a branch |
+| `gitmap checkout <NAME>` | Switch branches |
+| `gitmap diff [SOURCE] [TARGET]` | Compare staged state, branches, or commits |
+| `gitmap commit -m "message"` | Save the current map state as a commit |
+| `gitmap log --graph --oneline` | View history with branch context |
+| `gitmap merge <BRANCH>` | Merge a feature branch |
+| `gitmap push` | Publish the current state back to ArcGIS |
+| `gitmap pull` | Fetch the latest ArcGIS state into the repo |
+| `gitmap revert <COMMIT>` | Restore a previous commit without rewriting history |
+| `gitmap setup-repos` | Bulk-clone many maps |
+| `gitmap auto-pull` | Sync many repos on a schedule |
+| `gitmap context show` | Visualize repo event history |
 
 ## Configuration
 
-### Repository Config (`.gitmap/config.json`)
+GitMap looks for credentials in environment variables when repository config is not set.
 
-```json
-{
-    "version": "1.0",
-    "user_name": "Jane Smith",
-    "user_email": "jane@example.com",
-    "project_name": "FloodRisk",
-    "remote": {
-        "name": "origin",
-        "url": "https://www.arcgis.com",
-        "folder_id": "abc123",
-        "item_id": "def456"
-    }
-}
-```
-
-### Environment Variables
-
-| Variable | Description | Default |
-|---|---|---|
-| `PORTAL_URL` | Portal or AGOL URL | `https://www.arcgis.com` |
-| `PORTAL_USER` | Username | — |
-| `PORTAL_PASSWORD` | Password | — |
-| `ARCGIS_USERNAME` | Alternative username var | — |
-| `ARCGIS_PASSWORD` | Alternative password var | — |
-
-### Authentication Priority
-
-1. Command-line options (`--username`, `--password`)
-2. `.env` file
-3. ArcGIS Pro session (if running inside Pro)
-4. Anonymous (limited)
-
----
-
-## CLI Commands
-
-| Command | Description |
+| Variable | Description |
 |---|---|
-| `gitmap init` | Initialize a new repository |
-| `gitmap clone <item_id>` | Clone a web map from Portal |
-| `gitmap status` | Show working tree status |
-| `gitmap commit -m "msg"` | Record changes |
-| `gitmap branch [name]` | List or create branches |
-| `gitmap checkout <branch>` | Switch branches |
-| `gitmap diff` | Show changes |
-| `gitmap log` | Show commit history |
-| `gitmap merge <branch>` | Merge branches |
-| `gitmap push` | Push to Portal |
-| `gitmap pull` | Pull from Portal |
-| `gitmap list` | List Portal web maps |
-| `gitmap setup-repos` | Bulk clone multiple maps |
-| `gitmap auto-pull` | Sync all repos with Portal |
-| `gitmap lsm` | Transfer layer popup/form settings |
-| `gitmap notify` | Notify Portal group members |
-| `gitmap context` | Visualize event history |
-| `gitmap config` | Manage repo configuration |
-
----
-
-### `gitmap init`
-
-```bash
-gitmap init [PATH] [OPTIONS]
-
-Options:
-  --project-name, -n TEXT   Project name (defaults to directory name)
-  --user-name, -u TEXT      Default author name for commits
-  --user-email, -e TEXT     Default author email for commits
-
-Examples:
-  gitmap init
-  gitmap init --project-name "Flood Risk Map"
-  gitmap init /path/to/project --user-name "Jane Smith"
-```
-
-### `gitmap clone`
-
-```bash
-gitmap clone <ITEM_ID> [OPTIONS]
-
-Options:
-  --directory, -d TEXT   Clone into this directory (defaults to map title)
-  --url, -u TEXT         Portal URL (defaults to ArcGIS Online)
-  --username TEXT        Portal username (or use env var)
-
-Examples:
-  gitmap clone abc123def456
-  gitmap clone abc123def456 --directory my-project
-  gitmap clone abc123def456 --url https://portal.example.com
-```
-
-### `gitmap setup-repos`
-
-Bulk clone multiple web maps into a `repositories/` directory.
-
-```bash
-gitmap setup-repos [OPTIONS]
-
-Options:
-  --directory, -d TEXT     Output directory (default: repositories)
-  --owner, -o TEXT         Filter by owner username
-  --query, -q TEXT         Search query (e.g. 'title:MyMap')
-  --tag, -t TEXT           Filter by tag
-  --max-results, -m INT    Max maps to clone (default: 100)
-  --skip-existing          Skip already-cloned maps
-
-Examples:
-  gitmap setup-repos --owner myusername
-  gitmap setup-repos --tag production --skip-existing
-  gitmap setup-repos --query "title:Project*" --max-results 50
-```
-
-### `gitmap auto-pull`
-
-Sync all GitMap repositories in a directory with Portal.
-
-```bash
-gitmap auto-pull [OPTIONS]
-
-Options:
-  --directory, -d TEXT     Directory of repos (default: repositories)
-  --branch, -b TEXT        Branch to pull (default: main)
-  --auto-commit            Commit changes after pull
-  --commit-message, -m TEXT  Template: use {repo} and {date}
-  --skip-errors            Continue on failure
-
-Examples:
-  gitmap auto-pull
-  gitmap auto-pull --auto-commit
-  gitmap auto-pull --commit-message "Sync from Portal on {date}"
-
-# Automate with cron (every hour):
-  0 * * * * cd /path/to/project && gitmap auto-pull --auto-commit
-```
-
-### `gitmap list`
-
-```bash
-gitmap list [OPTIONS]
-
-Options:
-  --query, -q TEXT      Search query
-  --owner, -o TEXT      Filter by owner
-  --tag, -t TEXT        Filter by tag
-  --max-results, -m INT Max results (default: 100)
-
-Examples:
-  gitmap list
-  gitmap list --owner myusername --tag production
-  gitmap list --query "title:MyMap"
-```
-
-### `gitmap status`
-
-Show the working tree status — current branch, staged/unstaged changes, untracked files.
-
-```bash
-gitmap status
-```
-
-### `gitmap branch`
-
-```bash
-gitmap branch [BRANCH_NAME] [OPTIONS]
-
-Options:
-  --delete, -d    Delete a branch
-  --list, -l      List all branches
-
-Examples:
-  gitmap branch                    # List branches
-  gitmap branch feature/new-layer  # Create branch
-  gitmap branch -d feature/old     # Delete branch
-```
-
-### `gitmap checkout`
-
-```bash
-gitmap checkout <BRANCH_NAME>
-
-Examples:
-  gitmap checkout feature/new-layer
-  gitmap checkout main
-```
-
-### `gitmap commit`
-
-```bash
-gitmap commit [OPTIONS]
-
-Options:
-  --message, -m TEXT   Commit message (required)
-  --author TEXT        Override commit author
-
-Examples:
-  gitmap commit -m "Added hydrology layer"
-  gitmap commit -m "Fixed visibility" --author "Jane Smith"
-```
-
-### `gitmap diff`
-
-```bash
-gitmap diff [OPTIONS]
-
-Options:
-  --branch, -b TEXT   Compare with branch
-  --commit, -c TEXT   Compare with commit
-
-Examples:
-  gitmap diff                  # Working tree changes
-  gitmap diff --branch main    # vs main branch
-  gitmap diff --commit abc123  # vs specific commit
-```
-
-### `gitmap log`
-
-```bash
-gitmap log [OPTIONS]
-
-Options:
-  --branch, -b TEXT   Log for specific branch
-  --limit, -n INT     Limit number of commits
-
-Examples:
-  gitmap log
-  gitmap log --limit 10
-```
-
-### `gitmap merge`
-
-```bash
-gitmap merge <BRANCH_NAME>
-
-Example:
-  gitmap merge feature/new-layer
-```
-
-### `gitmap push` / `gitmap pull`
-
-```bash
-gitmap push [--branch BRANCH] [--url URL] [--username USER]
-gitmap pull [--branch BRANCH] [--url URL] [--username USER]
-```
-
-### `gitmap lsm`
-
-Transfer `popupInfo` and `formInfo` between maps.
-
-```bash
-gitmap lsm <SOURCE> [TARGET] [OPTIONS]
-
-Options:
-  --dry-run   Preview changes without applying
-
-Arguments:
-  SOURCE   item ID, branch name, commit ID, or file path
-  TARGET   optional; defaults to current index
-
-Examples:
-  gitmap lsm main feature/new-layer
-  gitmap lsm abc123def456
-  gitmap lsm source.json target.json --dry-run
-  gitmap lsm ../other-repo
-```
-
-### `gitmap notify`
-
-Send notifications to Portal group members via ArcGIS API.
-
-```bash
-gitmap notify --group <GROUP_ID_OR_TITLE> --subject "Subject" --message "Body"
-
-Options:
-  --group, -g TEXT       Group ID or title (required)
-  --user TEXT            Specific username (repeatable; omit for all members)
-  --subject, -s TEXT     Subject line
-  --message, -m TEXT     Message body
-  --message-file TEXT    Load message from file
-
-Examples:
-  gitmap notify --group editors --subject "New release" --message "Basemap updated."
-  gitmap notify --group editors --user testuser --subject "Test" --message "Hello"
-  gitmap notify --group "Field Crew" --subject "Prep" --message-file notes.txt
-```
-
-### `gitmap context`
-
-Visualize event history and relationships.
-
-```bash
-gitmap context <show|export|timeline|graph> [OPTIONS]
-
-show / timeline options:
-  --format, -f TEXT   ascii | mermaid | mermaid-timeline (default: ascii)
-  --limit, -n INT     Max events (default: 20)
-  --type, -t TEXT     Filter: commit|push|pull|merge|branch|diff
-
-export options:
-  --format, -f TEXT   mermaid | mermaid-timeline | mermaid-git | ascii | ascii-graph | html
-  --output, -o TEXT   Output file
-  --theme TEXT        light | dark (HTML only)
-  --title TEXT        Visualization title
-
-Examples:
-  gitmap context show
-  gitmap context show --format mermaid --type commit --type push
-  gitmap context export --format html --theme dark -o history.html
-  gitmap context timeline
-```
-
-### `gitmap config`
-
-```bash
-gitmap config [OPTIONS]
-
-Options:
-  --production-branch, -p TEXT   Set production branch
-  --unset-production             Remove production branch
-  --auto-visualize               Enable auto context graph
-  --no-auto-visualize            Disable auto context graph
-
-Examples:
-  gitmap config                              # View config
-  gitmap config --production-branch main
-  gitmap config --auto-visualize
-```
-
----
-
-## Usage Examples
-
-### Bulk Repository Setup
-
-```bash
-gitmap setup-repos --owner myusername --directory my-maps
-cd my-maps/MyWebMap
-gitmap status
-gitmap commit -m "Updated symbology"
-gitmap push
-```
-
-### Keep Repositories in Sync
-
-```bash
-# Manual sync
-gitmap auto-pull
-
-# Automated (cron, every hour)
-0 * * * * cd /path/to/project && gitmap auto-pull --auto-commit
-```
-
-### Feature Branch Workflow
-
-```bash
-gitmap checkout main
-gitmap branch feature/add-basemap
-gitmap checkout feature/add-basemap
-
-# Edit map JSON files...
-
-gitmap diff
-gitmap commit -m "Added satellite basemap option"
-gitmap push --branch feature/add-basemap
-
-gitmap checkout main
-gitmap merge feature/add-basemap
-gitmap push
-```
-
-### Compare Versions
-
-```bash
-gitmap diff --branch main
-gitmap diff --commit abc123
-gitmap log --limit 20
-```
-
-### Transfer Layer Settings
-
-```bash
-# Preview
-gitmap lsm main feature/new-layer --dry-run
-
-# Apply
-gitmap lsm main feature/new-layer
-
-# From Portal item ID
-gitmap lsm abc123def456
-```
-
----
-
-## Docker Setup
-
-```bash
-# Interactive dev shell
-docker-compose up dev
-
-# Run specific app
-APP_GROUP=cli APP_NAME=gitmap docker-compose up app
-```
-
----
+| `PORTAL_URL` | ArcGIS Online or Portal URL |
+| `ARCGIS_USERNAME` | ArcGIS username |
+| `ARCGIS_PASSWORD` | ArcGIS password |
+| `PORTAL_USER` | Alternate username variable |
+| `PORTAL_PASSWORD` | Alternate password variable |
+
+Authentication priority:
+
+1. Command-line options
+2. `.env` file
+3. ArcGIS Pro session
+4. Anonymous access where supported
+
+## Docs and references
+
+- [Installation guide](docs/getting-started/installation.md)
+- [Quickstart](docs/getting-started/quickstart.md)
+- [Core concepts](docs/getting-started/concepts.md)
+- [CLI command reference](docs/commands/index.md)
+- [Portal guide](docs/guides/portals.md)
+- [Workflow guide](docs/guides/workflow.md)
+- [Contributing](docs/contributing.md)
+- [Technical paper](docs/technical-paper.md)
 
 ## Development
 
-### Project Structure
-
+```bash
+cd /Users/tr-mini/Projects/git-map
+python -m pytest tests/ -x -q
 ```
+
+Project layout:
+
+```text
 Git-Map/
-├── apps/
-│   └── cli/gitmap/          # CLI application (gitmap-cli 0.7.0)
-├── packages/
-│   └── gitmap_core/         # Core library (gitmap_core 0.7.0)
-├── configs/                 # Config templates (.env.example)
-├── docker/                  # Docker config
-└── documentation/           # Specs and design docs
+├── apps/cli/gitmap/      # CLI package
+├── packages/gitmap_core/ # Core library
+├── docs/                 # MkDocs site and command docs
+├── configs/              # Example environment/config files
+└── tests/                # Test suite
 ```
-
-### Install for Development
-
-```bash
-pip install -e "packages/gitmap_core[dev]"
-pip install -e apps/cli/gitmap
-```
-
-### Run Tests
-
-```bash
-# All tests
-cd Git-Map && python -m pytest tests/ -x -q
-
-# With coverage
-python -m pytest packages/gitmap_core/tests --cov=packages/gitmap_core --cov-report=term-missing
-```
-
-### Code Standards
-
-- Python 3.11+
-- PEP 8, PEP 257
-- Type hints required
-- `pathlib.Path` for file operations
-
-### CI
-
-Tests run automatically on every push and PR via [GitHub Actions](https://github.com/14-TR/Git-Map/actions) across Python 3.11, 3.12, 3.13, and 3.14.
-
----
-
-## Architecture
-
-### Core Components
-
-**`gitmap_core`** — Core library:
-- Repository management (`.gitmap/` structure)
-- Portal authentication and connection
-- Web map JSON diffing and merging
-- Remote push/pull operations
-- Context graph visualization
-
-**`gitmap-cli`** — CLI layer:
-- 18 Git-like commands
-- Rich terminal output with colors
-- User-friendly error messages
-
-### Repository Layout
-
-```
-.gitmap/
-├── config.json      # Repo settings
-├── HEAD             # Current branch ref
-├── index.json       # Staging area
-├── refs/
-│   └── heads/       # Branch refs
-└── objects/
-    └── commits/     # Commit snapshots
-```
-
-### Data Model
-
-| Concept | Description |
-|---|---|
-| **Commit** | Snapshot of a map's JSON state + metadata |
-| **Branch** | Named pointer to a commit |
-| **Remote** | Portal connection config |
-| **Index** | Staging area (like `git add`) |
-
----
 
 ## Troubleshooting
 
-**Authentication errors**
-- Check `.env` exists and credentials are correct
-- Verify `PORTAL_URL` points to the right instance
-- Try passing `--username` / `--password` directly
+**Authentication failed**
+- Confirm `PORTAL_URL`, `ARCGIS_USERNAME`, and `ARCGIS_PASSWORD`
+- Verify the Portal URL is reachable
+- Try passing credentials directly on the command line
 
-**"Not connected. Call connect() first"**
-- Portal authentication failed — check `.env` config
+**Repository already exists**
+- Work inside the existing GitMap repo, or remove `.gitmap/` if you truly want a fresh start
 
-**"Repository already exists"**
-- Remove `.gitmap/` directory to start fresh, or work within the existing repo
-
-**"Failed to connect to Portal"**
-- Verify Portal URL is reachable from your network
-- Check firewall / VPN settings
-
----
+**Need to see what changed before pushing**
+- Run `gitmap diff --format visual`
+- Use `--verbose` for property-level changes
+- Export HTML when you need a shareable review artifact
 
 ## Contributing
 
-1. Fork the repo and create a `jig/*` branch
-2. Follow code standards (PEP 8, type hints, docstrings)
-3. Add tests for new features — keep coverage above 90%
-4. Open a PR with a clear description of what changed and why
-
----
+1. Fork the repo
+2. Create a `jig/*` or feature branch
+3. Add tests for behavior changes
+4. Run the test suite before opening a PR
+5. Open a PR with a clear summary and screenshots or sample output when useful
 
 ## License
 
-MIT — see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE).
 
----
-
-## Support & Community
-
-- [Open an issue](https://github.com/14-TR/Git-Map/issues)
-- [View documentation](documentation/)
-- [Changelog](CHANGELOG.md)
-
----
-
-**GitMap** — The git for GIS.
+**GitMap** — the git for GIS.

--- a/apps/cli/gitmap/__init__.py
+++ b/apps/cli/gitmap/__init__.py
@@ -11,10 +11,10 @@ Dependencies:
     - gitmap_core: Core library
 
 Metadata:
-    Version: 0.5.0
+    Version: 0.7.0
     Author: GitMap Team
 """
 
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.7.0"

--- a/integrations/openclaw/tests/test_tools.py
+++ b/integrations/openclaw/tests/test_tools.py
@@ -12,16 +12,18 @@ Dependencies:
 """
 from __future__ import annotations
 
+import importlib.util
 import subprocess
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Add integrations dir so tools can be imported standalone
-sys.path.insert(0, str(Path(__file__).parent.parent))
-import tools as gitmap_tools
+TOOLS_PATH = Path(__file__).resolve().parents[1] / "tools.py"
+TOOLS_SPEC = importlib.util.spec_from_file_location("gitmap_openclaw_tools", TOOLS_PATH)
+gitmap_tools = importlib.util.module_from_spec(TOOLS_SPEC)
+assert TOOLS_SPEC.loader is not None
+TOOLS_SPEC.loader.exec_module(gitmap_tools)
 
 
 # ---- _find_gitmap() ------------------------------------------------------------------

--- a/packages/gitmap_core/__init__.py
+++ b/packages/gitmap_core/__init__.py
@@ -11,7 +11,7 @@ Dependencies:
     - deepdiff: JSON comparison
 
 Metadata:
-    Version: 0.5.0
+    Version: 0.7.0
     Author: GitMap Team
 """
 
@@ -22,7 +22,7 @@ from gitmap_core.context import Annotation, ContextStore, Edge, Event
 from gitmap_core.models import Branch, Commit, Remote, RepoConfig
 from gitmap_core.visualize import GraphData
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 # Public API - core data models loaded eagerly
 __all__ = [

--- a/packages/gitmap_core/tests/test_cli_packaging.py
+++ b/packages/gitmap_core/tests/test_cli_packaging.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+from click.testing import CliRunner
+
+
+def _pyproject_version(pyproject_path: Path) -> str:
+    version_line = next(
+        line for line in pyproject_path.read_text().splitlines() if line.startswith("version = ")
+    )
+    return version_line.split('"')[1]
+
+
+def _load_module(module_name: str, file_path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_core_package_version_matches_pyproject() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(repo_root / "packages"))
+
+    import gitmap_core
+
+    pyproject_version = _pyproject_version(repo_root / "packages/gitmap_core/pyproject.toml")
+    assert gitmap_core.__version__ == pyproject_version
+
+
+def test_cli_package_version_matches_pyproject() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    cli_module = _load_module("gitmap_cli", repo_root / "apps/cli/gitmap/__init__.py")
+
+    pyproject_version = _pyproject_version(repo_root / "apps/cli/gitmap/pyproject.toml")
+    assert cli_module.__version__ == pyproject_version
+
+
+def test_cli_version_command_reports_pyproject_version() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    sys.path.insert(0, str(repo_root / "apps/cli/gitmap"))
+    sys.path.insert(0, str(repo_root / "packages"))
+
+    from main import cli
+
+    expected_version = _pyproject_version(repo_root / "apps/cli/gitmap/pyproject.toml")
+    result = CliRunner().invoke(cli, ["--version"])
+
+    assert result.exit_code == 0
+    assert expected_version in result.output

--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RELEASE_CHECKS_PATH = REPO_ROOT / "scripts/release_checks.py"
+
+
+def _load_release_checks_module():
+    spec = importlib.util.spec_from_file_location("release_checks", RELEASE_CHECKS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_versions_and_dependencies_are_synced() -> None:
+    release_checks = _load_release_checks_module()
+    state = release_checks.collect_release_state()
+
+    expected_version = state["root_version"]
+    assert state["core_version"] == expected_version
+    assert state["cli_version"] == expected_version
+    assert state["core_init_version"] == expected_version
+    assert state["cli_init_version"] == expected_version
+    assert state["cli_main_version"] == expected_version
+    assert f"gitmap-core>={expected_version}" in state["root_dependencies"]
+    assert f"gitmap-cli>={expected_version}" in state["root_dependencies"]
+    assert f"gitmap-core>={expected_version}" in state["cli_dependencies"]
+
+
+def test_release_metadata_and_publish_workflow_are_valid() -> None:
+    release_checks = _load_release_checks_module()
+    release_checks.validate_release_state()

--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -34,3 +34,11 @@ def test_release_versions_and_dependencies_are_synced() -> None:
 def test_release_metadata_and_publish_workflow_are_valid() -> None:
     release_checks = _load_release_checks_module()
     release_checks.validate_release_state()
+
+
+def test_release_metadata_requires_existing_readmes_and_typed_markers() -> None:
+    release_checks = _load_release_checks_module()
+
+    release_checks._validate_package_metadata(release_checks.ROOT_PYPROJECT)
+    release_checks._validate_package_metadata(release_checks.CORE_PYPROJECT)
+    release_checks._validate_package_metadata(release_checks.CLI_PYPROJECT)

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ROOT_PYPROJECT = REPO_ROOT / "pyproject.toml"
+CORE_PYPROJECT = REPO_ROOT / "packages/gitmap_core/pyproject.toml"
+CLI_PYPROJECT = REPO_ROOT / "apps/cli/gitmap/pyproject.toml"
+CORE_INIT = REPO_ROOT / "packages/gitmap_core/__init__.py"
+CLI_INIT = REPO_ROOT / "apps/cli/gitmap/__init__.py"
+CLI_MAIN = REPO_ROOT / "apps/cli/gitmap/main.py"
+PUBLISH_WORKFLOW = REPO_ROOT / ".github/workflows/publish.yml"
+
+
+def _load_pyproject(path: Path) -> dict:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _extract_version(path: Path, pattern: str) -> str:
+    text = path.read_text()
+    match = re.search(pattern, text)
+    if not match:
+        raise AssertionError(f"Could not find version in {path}")
+    return match.group(1)
+
+
+def collect_release_state() -> dict[str, str | list[str]]:
+    root_project = _load_pyproject(ROOT_PYPROJECT)["project"]
+    core_project = _load_pyproject(CORE_PYPROJECT)["project"]
+    cli_project = _load_pyproject(CLI_PYPROJECT)["project"]
+
+    root_version = root_project["version"]
+    core_version = core_project["version"]
+    cli_version = cli_project["version"]
+    core_init_version = _extract_version(CORE_INIT, r'__version__\s*=\s*"([^"]+)"')
+    cli_init_version = _extract_version(CLI_INIT, r'__version__\s*=\s*"([^"]+)"')
+    cli_main_version = _extract_version(CLI_MAIN, r'click\.version_option\(version="([^"]+)"')
+
+    return {
+        "root_version": root_version,
+        "core_version": core_version,
+        "cli_version": cli_version,
+        "core_init_version": core_init_version,
+        "cli_init_version": cli_init_version,
+        "cli_main_version": cli_main_version,
+        "root_dependencies": list(root_project.get("dependencies", [])),
+        "core_dependencies": list(core_project.get("dependencies", [])),
+        "cli_dependencies": list(cli_project.get("dependencies", [])),
+        "root_urls": sorted(root_project.get("urls", {}).keys()),
+        "core_urls": sorted(core_project.get("urls", {}).keys()),
+        "cli_urls": sorted(cli_project.get("urls", {}).keys()),
+    }
+
+
+def validate_release_state() -> None:
+    state = collect_release_state()
+    versions = {
+        state["root_version"],
+        state["core_version"],
+        state["cli_version"],
+        state["core_init_version"],
+        state["cli_init_version"],
+        state["cli_main_version"],
+    }
+    assert len(versions) == 1, f"Release versions are out of sync: {state}"
+
+    version = state["root_version"]
+    assert f"gitmap-core>={version}" in state["root_dependencies"], state["root_dependencies"]
+    assert f"gitmap-cli>={version}" in state["root_dependencies"], state["root_dependencies"]
+    assert f"gitmap-core>={version}" in state["cli_dependencies"], state["cli_dependencies"]
+
+    for pyproject in (ROOT_PYPROJECT, CORE_PYPROJECT, CLI_PYPROJECT):
+        project = _load_pyproject(pyproject)["project"]
+        assert project.get("readme") == "README.md", f"{pyproject} should publish README.md"
+        assert project.get("license", {}).get("text") == "MIT", f"{pyproject} should declare MIT license"
+        urls = project.get("urls", {})
+        for required_url in ("Homepage", "Repository", "Bug Tracker"):
+            assert required_url in urls, f"{pyproject} missing project.urls.{required_url}"
+
+    workflow_text = PUBLISH_WORKFLOW.read_text()
+    for tag_pattern in ('- "core-v*"', '- "cli-v*"', '- "v*"'):
+        assert tag_pattern in workflow_text, f"Missing publish tag pattern: {tag_pattern}"
+    for package_name in ("gitmap-core", "gitmap-cli", "gitmap"):
+        assert f"https://pypi.org/p/{package_name}" in workflow_text, f"Missing PyPI environment URL for {package_name}"
+
+
+if __name__ == "__main__":
+    validate_release_state()
+    state = collect_release_state()
+    print(f"Release metadata OK for GitMap v{state['root_version']}")

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -61,6 +61,46 @@ def collect_release_state() -> dict[str, str | list[str]]:
     }
 
 
+def _validate_package_metadata(pyproject: Path) -> None:
+    data = _load_pyproject(pyproject)
+    project = data["project"]
+
+    readme_path = pyproject.parent / project.get("readme", "")
+    assert project.get("readme") == "README.md", f"{pyproject} should publish README.md"
+    assert readme_path.is_file(), f"README declared by {pyproject} does not exist: {readme_path}"
+
+    assert project.get("license", {}).get("text") == "MIT", f"{pyproject} should declare MIT license"
+    urls = project.get("urls", {})
+    for required_url in ("Homepage", "Repository", "Bug Tracker"):
+        assert required_url in urls, f"{pyproject} missing project.urls.{required_url}"
+
+    classifiers = set(project.get("classifiers", []))
+    setuptools_tool = data.get("tool", {}).get("setuptools", {})
+    packages = setuptools_tool.get("packages", [])
+    package_data = setuptools_tool.get("package-data", {})
+    package_dirs = setuptools_tool.get("package-dir", {})
+
+    if "Typing :: Typed" in classifiers and packages:
+        for package_name in packages:
+            if "." in package_name:
+                continue
+
+            declared_package_data = package_data.get(package_name, [])
+            assert "py.typed" in declared_package_data, (
+                f"{pyproject} marks package as typed but does not declare py.typed for top-level package {package_name}"
+            )
+
+            configured_dir = package_dirs.get(package_name) or package_dirs.get("")
+            if configured_dir:
+                package_dir = pyproject.parent / configured_dir
+            else:
+                package_dir = pyproject.parent / package_name.replace('.', '/')
+
+            assert (package_dir / 'py.typed').is_file(), (
+                f"{pyproject} marks package as typed but is missing {package_dir / 'py.typed'}"
+            )
+
+
 def validate_release_state() -> None:
     state = collect_release_state()
     versions = {
@@ -79,12 +119,7 @@ def validate_release_state() -> None:
     assert f"gitmap-core>={version}" in state["cli_dependencies"], state["cli_dependencies"]
 
     for pyproject in (ROOT_PYPROJECT, CORE_PYPROJECT, CLI_PYPROJECT):
-        project = _load_pyproject(pyproject)["project"]
-        assert project.get("readme") == "README.md", f"{pyproject} should publish README.md"
-        assert project.get("license", {}).get("text") == "MIT", f"{pyproject} should declare MIT license"
-        urls = project.get("urls", {})
-        for required_url in ("Homepage", "Repository", "Bug Tracker"):
-            assert required_url in urls, f"{pyproject} missing project.urls.{required_url}"
+        _validate_package_metadata(pyproject)
 
     workflow_text = PUBLISH_WORKFLOW.read_text()
     for tag_pattern in ('- "core-v*"', '- "cli-v*"', '- "v*"'):


### PR DESCRIPTION
## Summary
- rewrite the root README around a faster onboarding flow
- add a true install -> quickstart -> merge/push narrative for first-time users
- highlight demo workflows, common commands, config, docs links, and troubleshooting

## Testing
- `python -m pytest tests/ -x -q` *(fails in this checkout: `python` command not found and `tests/` path does not exist)*
- `PYTHONPATH=packages python3 -m pytest packages/gitmap_core/tests -x -q` *(fails in this checkout: missing dependency `deepdiff` during test collection)*
