### PR TITLE
chore: smoke-test PyPI publish artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build gitmap-core wheel and sdist
         run: python -m build packages/gitmap_core --outdir dist/
 
+      - name: Smoke-test gitmap-core dist install
+        run: python scripts/verify_dist_install.py core
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -92,6 +95,9 @@ jobs:
       - name: Build gitmap-cli wheel and sdist
         run: python -m build apps/cli/gitmap --outdir dist/
 
+      - name: Smoke-test gitmap-cli dist install
+        run: python scripts/verify_dist_install.py cli
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -140,6 +146,9 @@ jobs:
 
       - name: Build gitmap wheel and sdist
         run: python -m build . --outdir dist/
+
+      - name: Smoke-test gitmap meta-package dist install
+        run: python scripts/verify_dist_install.py meta
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -61,13 +61,16 @@ Packages to configure:
 
 ## Publishing a New Release
 
-Before tagging, run the local release guardrail:
+Before tagging, run the local release guardrails:
 
 ```bash
 python3 scripts/release_checks.py
+python3 -m build packages/gitmap_core --outdir dist/
+python3 scripts/verify_dist_install.py core
 ```
 
-This verifies that the published package versions, dependency pins, project metadata, and publish workflow tag patterns are still aligned.
+This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned.
+The publish workflow now runs the same clean-venv install smoke test for `core`, `cli`, and `meta` before uploading artifacts to PyPI.
 
 ### Patch release (core fix)
 

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -126,6 +126,10 @@ def validate_release_state() -> None:
         assert tag_pattern in workflow_text, f"Missing publish tag pattern: {tag_pattern}"
     for package_name in ("gitmap-core", "gitmap-cli", "gitmap"):
         assert f"https://pypi.org/p/{package_name}" in workflow_text, f"Missing PyPI environment URL for {package_name}"
+    for dist_kind in ("core", "cli", "meta"):
+        assert f"python scripts/verify_dist_install.py {dist_kind}" in workflow_text, (
+            f"Missing dist smoke-test step for {dist_kind}"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/verify_dist_install.py
+++ b/scripts/verify_dist_install.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIST_DIR = REPO_ROOT / "dist"
+
+PACKAGE_CHECKS = {
+    "core": {
+        "package_name": "gitmap-core",
+        "required_prefixes": ["gitmap_core-"],
+        "commands": [
+            ["python", "-c", "import gitmap_core; print(gitmap_core.__version__)"],
+        ],
+    },
+    "cli": {
+        "package_name": "gitmap-cli",
+        "required_prefixes": ["gitmap_core-", "gitmap_cli-"],
+        "commands": [
+            ["python", "-c", "import gitmap_cli; print(gitmap_cli.__version__)"],
+            ["gitmap", "--version"],
+        ],
+    },
+    "meta": {
+        "package_name": "gitmap",
+        "required_prefixes": ["gitmap_core-", "gitmap_cli-", "gitmap-"],
+        "commands": [
+            ["python", "-c", "import gitmap_core, gitmap_cli; print(gitmap_core.__version__, gitmap_cli.__version__)"],
+            ["gitmap", "--version"],
+        ],
+    },
+}
+
+
+def _run(command: list[str], *, env: dict[str, str] | None = None) -> None:
+    subprocess.run(command, check=True, env=env)
+
+
+def _pick_artifact(prefix: str) -> Path:
+    matches = sorted(
+        path for path in DIST_DIR.iterdir()
+        if path.is_file() and path.name.startswith(prefix)
+    )
+    if not matches:
+        raise FileNotFoundError(f"No dist artifacts found for prefix {prefix!r} in {DIST_DIR}")
+
+    wheels = [path for path in matches if path.suffix == ".whl"]
+    return wheels[0] if wheels else matches[0]
+
+
+def verify(kind: str) -> None:
+    artifacts = [_pick_artifact(prefix) for prefix in PACKAGE_CHECKS[kind]["required_prefixes"]]
+    with tempfile.TemporaryDirectory(prefix=f"gitmap-{kind}-smoke-") as tmpdir:
+        venv_dir = Path(tmpdir) / "venv"
+        _run([sys.executable, "-m", "venv", str(venv_dir)])
+
+        bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+        python_bin = bin_dir / "python"
+        pip_bin = bin_dir / "pip"
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+
+        _run([str(python_bin), "-m", "pip", "install", "--upgrade", "pip"], env=env)
+        _run([str(pip_bin), "install", *[str(path) for path in artifacts]], env=env)
+
+        for command in PACKAGE_CHECKS[kind]["commands"]:
+            _run(command, env=env)
+
+    print(f"Verified installable dist artifacts for {PACKAGE_CHECKS[kind]['package_name']}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Smoke-test built GitMap distributions in a clean virtualenv")
+    parser.add_argument("kind", choices=sorted(PACKAGE_CHECKS), help="Distribution set to verify")
+    args = parser.parse_args()
+    verify(args.kind)


### PR DESCRIPTION
## Summary
- add a clean-venv smoke test script for built GitMap distributions
- run that smoke test in the publish workflow for core, cli, and meta package releases
- extend release guardrails/docs so the smoke-test requirement stays documented and enforced

## Testing
- `python3 scripts/release_checks.py`
- `python3 -m py_compile scripts/verify_dist_install.py`
- `PYTHONPATH=/Users/tr-mini/Projects/git-map/packages:/Users/tr-mini/Projects/git-map/apps/cli/gitmap /Users/tr-mini/Projects/git-map/.venv-architect/bin/python -m pytest packages/gitmap_core/tests -x -q`

## Notes
- The cron prompt suggested `python -m pytest tests/ -x -q`, but this repo currently has no top-level `tests/` directory; the active suite lives under `packages/gitmap_core/tests`.
