### PR TITLE
fix(cli): use gitmap in help and error output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Build gitmap-core wheel and sdist
         run: python -m build packages/gitmap_core --outdir dist/
 
+      - name: Smoke-test gitmap-core dist install
+        run: python scripts/verify_dist_install.py core
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -92,6 +95,9 @@ jobs:
       - name: Build gitmap-cli wheel and sdist
         run: python -m build apps/cli/gitmap --outdir dist/
 
+      - name: Smoke-test gitmap-cli dist install
+        run: python scripts/verify_dist_install.py cli
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -140,6 +146,9 @@ jobs:
 
       - name: Build gitmap wheel and sdist
         run: python -m build . --outdir dist/
+
+      - name: Smoke-test gitmap meta-package dist install
+        run: python scripts/verify_dist_install.py meta
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -61,13 +61,16 @@ Packages to configure:
 
 ## Publishing a New Release
 
-Before tagging, run the local release guardrail:
+Before tagging, run the local release guardrails:
 
 ```bash
 python3 scripts/release_checks.py
+python3 -m build packages/gitmap_core --outdir dist/
+python3 scripts/verify_dist_install.py core
 ```
 
-This verifies that the published package versions, dependency pins, project metadata, and publish workflow tag patterns are still aligned.
+This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned.
+The publish workflow now runs the same clean-venv install smoke test for `core`, `cli`, and `meta` before uploading artifacts to PyPI.
 
 ### Patch release (core fix)
 

--- a/apps/cli/gitmap/main.py
+++ b/apps/cli/gitmap/main.py
@@ -74,7 +74,7 @@ merge_from = _merge_from_module.merge_from
 # ---- Grouped Help ------------------------------------------------------------------------------------------
 
 
-@click.group(cls=GroupedHelpGroup)
+@click.group(name="gitmap", cls=GroupedHelpGroup)
 @click.version_option(version="0.7.0", prog_name="gitmap")
 def cli() -> None:
     """GitMap - Version control for ArcGIS web maps.

--- a/packages/gitmap_core/tests/test_cli_registration.py
+++ b/packages/gitmap_core/tests/test_cli_registration.py
@@ -134,6 +134,13 @@ class TestCommandRegistration:
         assert "gitmap init" in result.output
         assert "gitmap completions" in result.output
 
+    def test_help_uses_gitmap_prog_name(self, runner: CliRunner) -> None:
+        """Help output should show the installed command name, not the internal function name."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0
+        assert "Usage: gitmap [OPTIONS] COMMAND [ARGS]..." in result.output
+        assert "Usage: cli [OPTIONS] COMMAND [ARGS]..." not in result.output
+
     @pytest.mark.parametrize(
         ("mistyped", "expected"),
         [
@@ -147,6 +154,8 @@ class TestCommandRegistration:
         result = runner.invoke(cli, [mistyped])
         assert result.exit_code != 0
         assert "No such command" in result.output
+        assert "Try 'gitmap --help' for help." in result.output
         assert "Did you mean:" in result.output
         assert expected in result.output
         assert "gitmap --help" in result.output
+        assert "Try 'cli --help' for help." not in result.output

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -126,6 +126,10 @@ def validate_release_state() -> None:
         assert tag_pattern in workflow_text, f"Missing publish tag pattern: {tag_pattern}"
     for package_name in ("gitmap-core", "gitmap-cli", "gitmap"):
         assert f"https://pypi.org/p/{package_name}" in workflow_text, f"Missing PyPI environment URL for {package_name}"
+    for dist_kind in ("core", "cli", "meta"):
+        assert f"python scripts/verify_dist_install.py {dist_kind}" in workflow_text, (
+            f"Missing dist smoke-test step for {dist_kind}"
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/verify_dist_install.py
+++ b/scripts/verify_dist_install.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIST_DIR = REPO_ROOT / "dist"
+
+PACKAGE_CHECKS = {
+    "core": {
+        "package_name": "gitmap-core",
+        "required_prefixes": ["gitmap_core-"],
+        "commands": [
+            ["python", "-c", "import gitmap_core; print(gitmap_core.__version__)"],
+        ],
+    },
+    "cli": {
+        "package_name": "gitmap-cli",
+        "required_prefixes": ["gitmap_core-", "gitmap_cli-"],
+        "commands": [
+            ["python", "-c", "import gitmap_cli; print(gitmap_cli.__version__)"],
+            ["gitmap", "--version"],
+        ],
+    },
+    "meta": {
+        "package_name": "gitmap",
+        "required_prefixes": ["gitmap_core-", "gitmap_cli-", "gitmap-"],
+        "commands": [
+            ["python", "-c", "import gitmap_core, gitmap_cli; print(gitmap_core.__version__, gitmap_cli.__version__)"],
+            ["gitmap", "--version"],
+        ],
+    },
+}
+
+
+def _run(command: list[str], *, env: dict[str, str] | None = None) -> None:
+    subprocess.run(command, check=True, env=env)
+
+
+def _pick_artifact(prefix: str) -> Path:
+    matches = sorted(
+        path for path in DIST_DIR.iterdir()
+        if path.is_file() and path.name.startswith(prefix)
+    )
+    if not matches:
+        raise FileNotFoundError(f"No dist artifacts found for prefix {prefix!r} in {DIST_DIR}")
+
+    wheels = [path for path in matches if path.suffix == ".whl"]
+    return wheels[0] if wheels else matches[0]
+
+
+def verify(kind: str) -> None:
+    artifacts = [_pick_artifact(prefix) for prefix in PACKAGE_CHECKS[kind]["required_prefixes"]]
+    with tempfile.TemporaryDirectory(prefix=f"gitmap-{kind}-smoke-") as tmpdir:
+        venv_dir = Path(tmpdir) / "venv"
+        _run([sys.executable, "-m", "venv", str(venv_dir)])
+
+        bin_dir = venv_dir / ("Scripts" if sys.platform == "win32" else "bin")
+        python_bin = bin_dir / "python"
+        pip_bin = bin_dir / "pip"
+        env = dict(os.environ)
+        env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+
+        _run([str(python_bin), "-m", "pip", "install", "--upgrade", "pip"], env=env)
+        _run([str(pip_bin), "install", *[str(path) for path in artifacts]], env=env)
+
+        for command in PACKAGE_CHECKS[kind]["commands"]:
+            _run(command, env=env)
+
+    print(f"Verified installable dist artifacts for {PACKAGE_CHECKS[kind]['package_name']}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Smoke-test built GitMap distributions in a clean virtualenv")
+    parser.add_argument("kind", choices=sorted(PACKAGE_CHECKS), help="Distribution set to verify")
+    args = parser.parse_args()
+    verify(args.kind)


### PR DESCRIPTION
## Summary
- brand the top-level Click group as `gitmap` so usage/help output shows the installed command name instead of the internal `cli`
- cover the branded help/error copy with CLI registration tests

## Testing
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest /Users/tr-mini/Projects/git-map/packages/gitmap_core/tests/test_cli_registration.py -q`
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest /Users/tr-mini/Projects/git-map/packages/gitmap_core/tests/test_cli_packaging.py -q`
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest /Users/tr-mini/Projects/git-map/packages/gitmap_core/tests /Users/tr-mini/Projects/git-map/integrations/openclaw/tests -x -q`