### PR TITLE
ci: validate PyPI artifacts before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,33 @@ jobs:
         if: matrix.python-version == '3.11'
         run: |
           python -m pytest packages/gitmap_core/tests --cov=packages/gitmap_core --cov-report=term-missing --cov-fail-under=90
+
+  package-validation:
+    name: Package validation
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install packaging tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Verify release metadata invariants
+        run: python scripts/release_checks.py
+
+      - name: Build distributable artifacts
+        run: |
+          python -m build packages/gitmap_core --outdir dist/core
+          python -m build apps/cli/gitmap --outdir dist/cli
+          python -m build . --outdir dist/meta
+
+      - name: Check rendered package metadata
+        run: python -m twine check dist/core/* dist/cli/* dist/meta/*

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -18,6 +18,7 @@ CORE_INIT = REPO_ROOT / "packages/gitmap_core/__init__.py"
 CLI_INIT = REPO_ROOT / "apps/cli/gitmap/__init__.py"
 CLI_MAIN = REPO_ROOT / "apps/cli/gitmap/main.py"
 PUBLISH_WORKFLOW = REPO_ROOT / ".github/workflows/publish.yml"
+CI_WORKFLOW = REPO_ROOT / ".github/workflows/ci.yml"
 
 
 def _load_pyproject(path: Path) -> dict:
@@ -126,6 +127,17 @@ def validate_release_state() -> None:
         assert tag_pattern in workflow_text, f"Missing publish tag pattern: {tag_pattern}"
     for package_name in ("gitmap-core", "gitmap-cli", "gitmap"):
         assert f"https://pypi.org/p/{package_name}" in workflow_text, f"Missing PyPI environment URL for {package_name}"
+
+    ci_workflow_text = CI_WORKFLOW.read_text()
+    assert "package-validation:" in ci_workflow_text, "CI workflow missing package validation job"
+    for expected_command in (
+        "python scripts/release_checks.py",
+        "python -m build packages/gitmap_core --outdir dist/core",
+        "python -m build apps/cli/gitmap --outdir dist/cli",
+        "python -m build . --outdir dist/meta",
+        "python -m twine check dist/core/* dist/cli/* dist/meta/*",
+    ):
+        assert expected_command in ci_workflow_text, f"CI workflow missing packaging command: {expected_command}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a dedicated CI packaging job after the test matrix passes
- verify release metadata invariants before building distributions
- build core, CLI, and meta-package artifacts and run `twine check` on all of them

## Testing
- `PYTHONPATH=/Users/tr-mini/Projects/git-map/packages python3 -m pytest packages/gitmap_core/tests/test_release_checks.py -q`
- `python3 scripts/release_checks.py`

## Notes
- I did not run the full test suite locally because this environment is missing optional runtime deps used by broader CLI tests (`deepdiff` import path surfaced during collection). The existing matrix test job remains the gate before merge.
