### PR TITLE
fix: restore root gitmap meta-package build

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -66,10 +66,14 @@ Before tagging, run the local release guardrails:
 ```bash
 python3 scripts/release_checks.py
 python3 -m build packages/gitmap_core --outdir dist/
+python3 -m build apps/cli/gitmap --outdir dist/
+python3 -m build . --outdir dist/
 python3 scripts/verify_dist_install.py core
+python3 scripts/verify_dist_install.py cli
+python3 scripts/verify_dist_install.py meta
 ```
 
-This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned.
+This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned. It also catches root meta-package build regressions, which is important in this monorepo because setuptools can otherwise try to auto-discover top-level folders instead of building the `gitmap` meta-package.
 The publish workflow now runs the same clean-venv install smoke test for `core`, `cli`, and `meta` before uploading artifacts to PyPI.
 
 ### Patch release (core fix)

--- a/apps/cli/gitmap/commands/branch.py
+++ b/apps/cli/gitmap/commands/branch.py
@@ -166,6 +166,8 @@ def branch(
         else:
             console.print("[dim]Branch created (no commits yet)[/dim]")
 
+    except click.ClickException:
+        raise
     except Exception as branch_error:
         msg = f"Branch operation failed: {branch_error}"
         raise click.ClickException(msg) from branch_error

--- a/apps/cli/gitmap/commands/tag.py
+++ b/apps/cli/gitmap/commands/tag.py
@@ -123,6 +123,8 @@ def tag(
         if commit_obj:
             console.print(f"  [bold]Message:[/bold] {commit_obj.message.split(chr(10))[0]}")
 
+    except click.ClickException:
+        raise
     except Exception as tag_error:
         msg = f"Tag operation failed: {tag_error}"
         raise click.ClickException(msg) from tag_error

--- a/packages/gitmap_core/tests/test_cli_error_messages.py
+++ b/packages/gitmap_core/tests/test_cli_error_messages.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+
+_repo_root = Path(__file__).resolve().parents[3]
+_cli_dir = _repo_root / 'apps' / 'cli' / 'gitmap'
+_cli_commands_dir = _cli_dir / 'commands'
+
+if 'gitmap_cli' not in sys.modules:
+    _pkg = types.ModuleType('gitmap_cli')
+    _pkg.__path__ = [str(_cli_dir)]
+    _pkg.__package__ = 'gitmap_cli'
+    sys.modules['gitmap_cli'] = _pkg
+
+if 'gitmap_cli.commands' not in sys.modules:
+    _cmds = types.ModuleType('gitmap_cli.commands')
+    _cmds.__path__ = [str(_cli_commands_dir)]
+    _cmds.__package__ = 'gitmap_cli.commands'
+    sys.modules['gitmap_cli.commands'] = _cmds
+
+if str(_cli_dir) not in sys.path:
+    sys.path.insert(0, str(_cli_dir))
+
+import gitmap_cli.commands.branch as branch_module  # noqa: E402
+import gitmap_cli.commands.tag as tag_module  # noqa: E402
+
+branch = branch_module.branch
+tag = tag_module.tag
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_branch_delete_without_name_surfaces_actionable_click_error(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
+    repo = Mock()
+    repo.get_current_branch.return_value = 'main'
+    monkeypatch.setattr(branch_module, 'find_repository', lambda: repo)
+
+    result = runner.invoke(branch, ['--delete'])
+
+    assert result.exit_code != 0
+    assert 'Branch name required.' in result.output
+    assert 'Usage: gitmap branch <name>' in result.output
+    assert 'Branch operation failed:' not in result.output
+
+
+def test_tag_without_name_surfaces_usage_instead_of_generic_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    repo = Mock()
+    monkeypatch.setattr(tag_module, 'find_repository', lambda: repo)
+
+    result = runner.invoke(tag, [])
+
+    assert result.exit_code != 0
+    assert 'Usage: gitmap tag <name> [commit] or gitmap tag --list' in result.output
+    assert 'Tag operation failed:' not in result.output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ Changelog = "https://github.com/14-TR/Git-Map/blob/main/CHANGELOG.md"
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = []
+
 # ---- Dev tools (not published) -------------------------------------------------------------------------
 
 [project.optional-dependencies]

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -78,6 +78,12 @@ def _validate_package_metadata(pyproject: Path) -> None:
     classifiers = set(project.get("classifiers", []))
     setuptools_tool = data.get("tool", {}).get("setuptools", {})
     packages = setuptools_tool.get("packages", [])
+
+    if pyproject == ROOT_PYPROJECT:
+        assert packages == [], (
+            f"{pyproject} should explicitly declare an empty package list so the meta-package build does not auto-discover monorepo folders"
+        )
+
     package_data = setuptools_tool.get("package-data", {})
     package_dirs = setuptools_tool.get("package-dir", {})
 


### PR DESCRIPTION
## Summary
- make the root `gitmap` package explicitly declare an empty package list so setuptools stops auto-discovering monorepo folders
- add a release guardrail that fails if the root meta-package stops declaring `packages = []`
- expand the publishing checklist so local release validation covers core, cli, and meta builds

## Testing
- `/opt/homebrew/bin/python3 scripts/release_checks.py`
- `PYTHONPATH=/Users/tr-mini/Projects/git-map/packages /opt/homebrew/bin/python3 -m pytest /Users/tr-mini/Projects/git-map/packages/gitmap_core/tests -x -q`
- `/opt/homebrew/bin/python3 -m build /Users/tr-mini/Projects/git-map/packages/gitmap_core --outdir /Users/tr-mini/Projects/git-map/dist`
- `/opt/homebrew/bin/python3 -m build /Users/tr-mini/Projects/git-map/apps/cli/gitmap --outdir /Users/tr-mini/Projects/git-map/dist`
- `/opt/homebrew/bin/python3 -m build /Users/tr-mini/Projects/git-map --outdir /Users/tr-mini/Projects/git-map/dist`

## Notes
- this fixes the root package build failure that produced `UNKNOWN-0.0.0` / multiple top-level package discovery errors for the meta-package