### PR TITLE
Add CI smoke tests for built packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,27 @@ jobs:
 
       - name: Check rendered package metadata
         run: python -m twine check dist/core/* dist/cli/* dist/meta/*
+
+      - name: Smoke-test built package installs
+        run: |
+          mv dist dist-build
+
+          mkdir -p dist
+          cp dist-build/core/* dist/
+          python scripts/verify_dist_install.py core
+
+          rm -rf dist
+          mkdir -p dist
+          cp dist-build/core/* dist/
+          cp dist-build/cli/* dist/
+          python scripts/verify_dist_install.py cli
+
+          rm -rf dist
+          mkdir -p dist
+          cp dist-build/core/* dist/
+          cp dist-build/cli/* dist/
+          cp dist-build/meta/* dist/
+          python scripts/verify_dist_install.py meta
+
+          rm -rf dist
+          mv dist-build dist

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -66,10 +66,14 @@ Before tagging, run the local release guardrails:
 ```bash
 python3 scripts/release_checks.py
 python3 -m build packages/gitmap_core --outdir dist/
+python3 -m build apps/cli/gitmap --outdir dist/
+python3 -m build . --outdir dist/
 python3 scripts/verify_dist_install.py core
+python3 scripts/verify_dist_install.py cli
+python3 scripts/verify_dist_install.py meta
 ```
 
-This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned.
+This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned. It also catches root meta-package build regressions, which is important in this monorepo because setuptools can otherwise try to auto-discover top-level folders instead of building the `gitmap` meta-package.
 The publish workflow now runs the same clean-venv install smoke test for `core`, `cli`, and `meta` before uploading artifacts to PyPI.
 
 ### Patch release (core fix)

--- a/apps/cli/gitmap/commands/branch.py
+++ b/apps/cli/gitmap/commands/branch.py
@@ -166,6 +166,8 @@ def branch(
         else:
             console.print("[dim]Branch created (no commits yet)[/dim]")
 
+    except click.ClickException:
+        raise
     except Exception as branch_error:
         msg = f"Branch operation failed: {branch_error}"
         raise click.ClickException(msg) from branch_error

--- a/apps/cli/gitmap/commands/tag.py
+++ b/apps/cli/gitmap/commands/tag.py
@@ -123,6 +123,8 @@ def tag(
         if commit_obj:
             console.print(f"  [bold]Message:[/bold] {commit_obj.message.split(chr(10))[0]}")
 
+    except click.ClickException:
+        raise
     except Exception as tag_error:
         msg = f"Tag operation failed: {tag_error}"
         raise click.ClickException(msg) from tag_error

--- a/packages/gitmap_core/tests/test_cli_error_messages.py
+++ b/packages/gitmap_core/tests/test_cli_error_messages.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from click.testing import CliRunner
+
+_repo_root = Path(__file__).resolve().parents[3]
+_cli_dir = _repo_root / 'apps' / 'cli' / 'gitmap'
+_cli_commands_dir = _cli_dir / 'commands'
+
+if 'gitmap_cli' not in sys.modules:
+    _pkg = types.ModuleType('gitmap_cli')
+    _pkg.__path__ = [str(_cli_dir)]
+    _pkg.__package__ = 'gitmap_cli'
+    sys.modules['gitmap_cli'] = _pkg
+
+if 'gitmap_cli.commands' not in sys.modules:
+    _cmds = types.ModuleType('gitmap_cli.commands')
+    _cmds.__path__ = [str(_cli_commands_dir)]
+    _cmds.__package__ = 'gitmap_cli.commands'
+    sys.modules['gitmap_cli.commands'] = _cmds
+
+if str(_cli_dir) not in sys.path:
+    sys.path.insert(0, str(_cli_dir))
+
+import gitmap_cli.commands.branch as branch_module  # noqa: E402
+import gitmap_cli.commands.tag as tag_module  # noqa: E402
+
+branch = branch_module.branch
+tag = tag_module.tag
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def test_branch_delete_without_name_surfaces_actionable_click_error(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
+    repo = Mock()
+    repo.get_current_branch.return_value = 'main'
+    monkeypatch.setattr(branch_module, 'find_repository', lambda: repo)
+
+    result = runner.invoke(branch, ['--delete'])
+
+    assert result.exit_code != 0
+    assert 'Branch name required.' in result.output
+    assert 'Usage: gitmap branch <name>' in result.output
+    assert 'Branch operation failed:' not in result.output
+
+
+def test_tag_without_name_surfaces_usage_instead_of_generic_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    repo = Mock()
+    monkeypatch.setattr(tag_module, 'find_repository', lambda: repo)
+
+    result = runner.invoke(tag, [])
+
+    assert result.exit_code != 0
+    assert 'Usage: gitmap tag <name> [commit] or gitmap tag --list' in result.output
+    assert 'Tag operation failed:' not in result.output

--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -36,6 +36,18 @@ def test_release_metadata_and_publish_workflow_are_valid() -> None:
     release_checks.validate_release_state()
 
 
+def test_ci_package_validation_smoke_tests_dist_installs() -> None:
+    release_checks = _load_release_checks_module()
+    ci_workflow_text = release_checks.CI_WORKFLOW.read_text()
+
+    for expected_command in (
+        "python scripts/verify_dist_install.py core",
+        "python scripts/verify_dist_install.py cli",
+        "python scripts/verify_dist_install.py meta",
+    ):
+        assert expected_command in ci_workflow_text
+
+
 def test_release_metadata_requires_existing_readmes_and_typed_markers() -> None:
     release_checks = _load_release_checks_module()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ Changelog = "https://github.com/14-TR/Git-Map/blob/main/CHANGELOG.md"
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+packages = []
+
 # ---- Dev tools (not published) -------------------------------------------------------------------------
 
 [project.optional-dependencies]

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -78,6 +78,12 @@ def _validate_package_metadata(pyproject: Path) -> None:
     classifiers = set(project.get("classifiers", []))
     setuptools_tool = data.get("tool", {}).get("setuptools", {})
     packages = setuptools_tool.get("packages", [])
+
+    if pyproject == ROOT_PYPROJECT:
+        assert packages == [], (
+            f"{pyproject} should explicitly declare an empty package list so the meta-package build does not auto-discover monorepo folders"
+        )
+
     package_data = setuptools_tool.get("package-data", {})
     package_dirs = setuptools_tool.get("package-dir", {})
 

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -146,6 +146,9 @@ def validate_release_state() -> None:
         "python -m build apps/cli/gitmap --outdir dist/cli",
         "python -m build . --outdir dist/meta",
         "python -m twine check dist/core/* dist/cli/* dist/meta/*",
+        "python scripts/verify_dist_install.py core",
+        "python scripts/verify_dist_install.py cli",
+        "python scripts/verify_dist_install.py meta",
     ):
         assert expected_command in ci_workflow_text, f"CI workflow missing packaging command: {expected_command}"
 


### PR DESCRIPTION
## Summary
- add package-install smoke tests to the CI package-validation job
- verify `core`, `cli`, and `meta` distributions in clean venvs before merge
- extend release guardrails so future CI edits must keep those smoke-test steps

## Testing
- ./.venv/bin/python -m pytest packages/gitmap_core/tests/test_release_checks.py -q
- ./.venv/bin/python scripts/release_checks.py
- ./.venv/bin/python scripts/verify_dist_install.py core
