### PR TITLE
Add release tag guardrails to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install build tools
         run: python -m pip install --upgrade pip build
 
+      - name: Validate release tag
+        run: python scripts/release_checks.py --ref-name "${{ github.ref_name }}"
+
       - name: Run tests before publishing
         run: |
           pip install -e "packages/gitmap_core[dev]"
@@ -87,6 +90,9 @@ jobs:
       - name: Install build tools
         run: python -m pip install --upgrade pip build
 
+      - name: Validate release tag
+        run: python scripts/release_checks.py --ref-name "${{ github.ref_name }}"
+
       - name: Run core tests (CLI depends on core)
         run: |
           pip install -e "packages/gitmap_core[dev]"
@@ -138,6 +144,9 @@ jobs:
 
       - name: Install build tools
         run: python -m pip install --upgrade pip build
+
+      - name: Validate release tag
+        run: python scripts/release_checks.py --ref-name "${{ github.ref_name }}"
 
       - name: Run core tests before publishing
         run: |

--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RELEASE_CHECKS_PATH = REPO_ROOT / "scripts/release_checks.py"
@@ -54,3 +56,60 @@ def test_release_metadata_requires_existing_readmes_and_typed_markers() -> None:
     release_checks._validate_package_metadata(release_checks.ROOT_PYPROJECT)
     release_checks._validate_package_metadata(release_checks.CORE_PYPROJECT)
     release_checks._validate_package_metadata(release_checks.CLI_PYPROJECT)
+
+
+@pytest.mark.parametrize(
+    ("ref_name", "expected_version"),
+    [
+        ("refs/tags/core-v1.2.3", "1.2.3"),
+        ("cli-v1.2.3", "1.2.3"),
+        ("v1.2.3", "1.2.3"),
+    ],
+)
+def test_validate_release_tag_accepts_matching_tags(ref_name: str, expected_version: str) -> None:
+    release_checks = _load_release_checks_module()
+
+    release_checks.validate_release_tag(
+        ref_name,
+        state={
+            "root_version": expected_version,
+            "core_version": expected_version,
+            "cli_version": expected_version,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("ref_name", "state", "message"),
+    [
+        (
+            "refs/tags/core-v9.9.9",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "expected version 1.2.3",
+        ),
+        (
+            "cli-v2.0.0",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "expected version 1.2.3",
+        ),
+        (
+            "v0.0.1",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "expected version 1.2.3",
+        ),
+        (
+            "refs/heads/main",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "Release tag must be one of",
+        ),
+    ],
+)
+def test_validate_release_tag_rejects_mismatched_or_invalid_tags(
+    ref_name: str,
+    state: dict[str, str],
+    message: str,
+) -> None:
+    release_checks = _load_release_checks_module()
+
+    with pytest.raises(AssertionError, match=message):
+        release_checks.validate_release_tag(ref_name, state=state)

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -108,6 +109,28 @@ def _validate_package_metadata(pyproject: Path) -> None:
             )
 
 
+def validate_release_tag(ref_name: str, state: dict[str, str | list[str]] | None = None) -> None:
+    normalized_ref = ref_name.removeprefix("refs/tags/")
+    tag_match = re.fullmatch(r"(?:(core|cli)-)?v(.+)", normalized_ref)
+    assert tag_match, (
+        "Release tag must be one of core-v<version>, cli-v<version>, or v<version>: "
+        f"{ref_name}"
+    )
+
+    package_prefix, tag_version = tag_match.groups()
+    state = state or collect_release_state()
+    expected_versions = {
+        None: state["root_version"],
+        "core": state["core_version"],
+        "cli": state["cli_version"],
+    }
+    expected_version = expected_versions[package_prefix]
+    assert tag_version == expected_version, (
+        f"Release tag {normalized_ref} does not match expected version {expected_version}"
+    )
+
+
+
 def validate_release_state() -> None:
     state = collect_release_state()
     versions = {
@@ -153,7 +176,20 @@ def validate_release_state() -> None:
         assert expected_command in ci_workflow_text, f"CI workflow missing packaging command: {expected_command}"
 
 
-if __name__ == "__main__":
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ref-name", help="Git ref/tag name to validate against release metadata")
+    args = parser.parse_args()
+
     validate_release_state()
     state = collect_release_state()
+    if args.ref_name:
+        validate_release_tag(args.ref_name, state=state)
+        print(f"Release metadata OK for {args.ref_name} (GitMap v{state['root_version']})")
+        return
+
     print(f"Release metadata OK for GitMap v{state['root_version']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add release tag validation support to scripts/release_checks.py with optional --ref-name handling
- cover matching and mismatched core/cli/meta release tags in test_release_checks.py
- run release tag validation in each publish build job before tests/builds

## Testing
- source .venv-release-checks/bin/activate && python -m pytest packages/gitmap_core/tests/test_release_checks.py -q
- source .venv-release-checks/bin/activate && python scripts/release_checks.py --ref-name v0.7.0
- source .venv-release-checks/bin/activate && python scripts/release_checks.py --ref-name core-v0.7.0
- source .venv-release-checks/bin/activate && python scripts/release_checks.py --ref-name refs/tags/cli-v0.7.0