### PR TITLE
docs: clarify install and first-run setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install build tools
         run: python -m pip install --upgrade pip build
 
+      - name: Validate release tag
+        run: python scripts/release_checks.py --ref-name "${{ github.ref_name }}"
+
       - name: Run tests before publishing
         run: |
           pip install -e "packages/gitmap_core[dev]"
@@ -87,6 +90,9 @@ jobs:
       - name: Install build tools
         run: python -m pip install --upgrade pip build
 
+      - name: Validate release tag
+        run: python scripts/release_checks.py --ref-name "${{ github.ref_name }}"
+
       - name: Run core tests (CLI depends on core)
         run: |
           pip install -e "packages/gitmap_core[dev]"
@@ -138,6 +144,9 @@ jobs:
 
       - name: Install build tools
         run: python -m pip install --upgrade pip build
+
+      - name: Validate release tag
+        run: python scripts/release_checks.py --ref-name "${{ github.ref_name }}"
 
       - name: Run core tests before publishing
         run: |

--- a/README.md
+++ b/README.md
@@ -60,34 +60,44 @@ Git-Map solves that with version-control primitives GIS teams already understand
 ### Requirements
 
 - Python 3.11, 3.12, 3.13, or 3.14
-- ArcGIS Online or Portal for ArcGIS access
+- ArcGIS Online account or Portal for ArcGIS access
 
-### Install from PyPI
+### Recommended: install from PyPI
 
 ```bash
 pip install gitmap
-```
-
-Verify:
-
-```bash
 gitmap --version
 ```
 
-### Install from source
+This installs the `gitmap` command plus the core library in one step.
+
+### Install from source for development
 
 ```bash
 git clone https://github.com/14-TR/Git-Map.git
 cd Git-Map
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -e "packages/gitmap_core[dev]"
 pip install -e apps/cli/gitmap
+gitmap --version
 ```
 
 ## 5-minute quickstart
 
 ### 1. Configure credentials
 
-Copy the example environment file:
+Git-Map supports either ArcGIS-style or Portal-style environment variable names.
+
+```bash
+export PORTAL_URL=https://your-org.maps.arcgis.com
+export ARCGIS_USERNAME=your_username
+export ARCGIS_PASSWORD=your_password
+```
+
+If your team already uses `PORTAL_USER` / `PORTAL_PASSWORD`, those also work.
+
+You can also copy the example environment file:
 
 ```bash
 cp configs/env.example .env
@@ -97,8 +107,11 @@ Then set your portal details:
 
 ```env
 PORTAL_URL=https://your-org.maps.arcgis.com
-PORTAL_USER=your_username
-PORTAL_PASSWORD=your_password
+ARCGIS_USERNAME=your_username
+ARCGIS_PASSWORD=your_password
+# Optional backwards-compatible aliases:
+# PORTAL_USER=your_username
+# PORTAL_PASSWORD=your_password
 ```
 
 `.env` is ignored by Git and should never be committed.
@@ -125,7 +138,7 @@ gitmap checkout feature/hydrology-update
 
 ### 4. Make edits and review the diff
 
-After editing the tracked map files:
+After editing the tracked map files or pulling down Portal changes:
 
 ```bash
 gitmap status
@@ -148,6 +161,18 @@ gitmap push
 ```
 
 That is the core Git-Map loop: **clone or init -> branch -> change -> diff -> commit -> push -> merge**.
+
+## First-run checklist
+
+If this is your first time using Git-Map, this is the fastest sanity check:
+
+1. `gitmap --version`
+2. set `PORTAL_URL`, `ARCGIS_USERNAME`, and `ARCGIS_PASSWORD`
+3. run `gitmap doctor`
+4. clone a known test map with `gitmap clone <item-id>`
+5. confirm `gitmap status` shows a clean working tree
+
+If auth fails, double-check the variable names in your shell or `.env` file before debugging anything deeper.
 
 ## Typical workflows
 
@@ -254,10 +279,10 @@ Git-Map supports several ways to provide credentials and repository settings.
 | Variable | Description |
 |---|---|
 | `PORTAL_URL` | Portal or ArcGIS Online URL |
-| `PORTAL_USER` | Portal username |
-| `PORTAL_PASSWORD` | Portal password |
-| `ARCGIS_USERNAME` | Alternate username variable |
-| `ARCGIS_PASSWORD` | Alternate password variable |
+| `ARCGIS_USERNAME` | Preferred ArcGIS/Portal username variable |
+| `ARCGIS_PASSWORD` | Preferred ArcGIS/Portal password variable |
+| `PORTAL_USER` | Backwards-compatible username alias |
+| `PORTAL_PASSWORD` | Backwards-compatible password alias |
 
 ### Repository config
 
@@ -315,6 +340,8 @@ python -m pytest packages/gitmap_core/tests integrations/openclaw/tests -x -q
 ## Documentation and support
 
 - Documentation site: <https://14-tr.github.io/Git-Map/>
+- Installation guide: <https://14-tr.github.io/Git-Map/getting-started/installation/>
+- Quickstart: <https://14-tr.github.io/Git-Map/getting-started/quickstart/>
 - Technical paper: <https://14-tr.github.io/Git-Map/technical-paper/>
 - Issues: <https://github.com/14-TR/Git-Map/issues>
 - Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/apps/cli/gitmap/main.py
+++ b/apps/cli/gitmap/main.py
@@ -128,7 +128,7 @@ def main() -> int:
         Exit code (0 for success, non-zero for errors).
     """
     try:
-        cli()
+        cli(prog_name="gitmap")
         return 0
     except Exception as cli_error:
         click.echo(f"Error: {cli_error}", err=True)

--- a/configs/env.example
+++ b/configs/env.example
@@ -1,19 +1,20 @@
 # Copy this file to .env in the project root and fill in your values
 # .env is git-ignored and should never be committed
 
-# ArcGIS Portal/AGOL Connection
+# ArcGIS Portal/AGOL connection
 PORTAL_URL=https://your-org.maps.arcgis.com
-PORTAL_USER=your_username
-PORTAL_PASSWORD=your_password
+ARCGIS_USERNAME=your_username
+ARCGIS_PASSWORD=your_password
+
+# Optional backwards-compatible aliases used by older setups
+# PORTAL_USER=your_username
+# PORTAL_PASSWORD=your_password
 
 # Optional: OAuth client credentials (alternative to username/password)
 # CLIENT_ID=your_client_id
 # CLIENT_SECRET=your_client_secret
 
-# Docker Compose: Repositories path
+# Docker Compose: repositories path
 # For dev containers, this defaults to ./repositories (workspace relative)
 # For local Docker Compose, you can override with an absolute path:
 # REPOSITORIES_PATH=your/path/here
-
-
-

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,48 +9,62 @@
 
 ```bash
 pip install gitmap
+gitmap --version
 ```
 
 This installs both the core library and the `gitmap` CLI command in one step.
-
-Verify the install:
-
-```bash
-gitmap --version
-```
 
 !!! tip "Individual packages"
     If you only need the library (no CLI), install `gitmap-core` directly.
     The `gitmap` meta-package is the recommended install for most users.
 
-## Install from Source
+## Install from source
 
 ```bash
 git clone https://github.com/14-TR/Git-Map.git
 cd Git-Map
-
-# Install core library + CLI
-pip install -e "packages/gitmap_core"
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e "packages/gitmap_core[dev]"
 pip install -e "apps/cli/gitmap"
-```
-
-Verify:
-
-```bash
 gitmap --version
 ```
 
-## Environment Variables
+## Environment variables
 
 Git-Map reads credentials from environment variables when no config is set:
 
 | Variable | Description |
 |----------|-------------|
-| `ARCGIS_USERNAME` | Your ArcGIS/Portal username |
-| `ARCGIS_PASSWORD` | Your ArcGIS/Portal password |
 | `PORTAL_URL` | Your Portal URL (defaults to `https://www.arcgis.com`) |
+| `ARCGIS_USERNAME` | Preferred ArcGIS/Portal username variable |
+| `ARCGIS_PASSWORD` | Preferred ArcGIS/Portal password variable |
+| `PORTAL_USER` | Backwards-compatible username alias |
+| `PORTAL_PASSWORD` | Backwards-compatible password alias |
+
+Example `.env` file:
+
+```env
+PORTAL_URL=https://your-org.maps.arcgis.com
+ARCGIS_USERNAME=your_username
+ARCGIS_PASSWORD=your_password
+# Optional backwards-compatible aliases:
+# PORTAL_USER=your_username
+# PORTAL_PASSWORD=your_password
+```
 
 You can also store credentials in the repository config file — see [Working with Portals](../guides/portals.md).
+
+## First-run verification
+
+After installing, run:
+
+```bash
+gitmap --version
+gitmap doctor
+```
+
+If `gitmap doctor` reports missing credentials, check your shell or `.env` file for typos before trying a clone or push.
 
 ## Upgrading
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -11,7 +11,7 @@ pip install gitmap
 gitmap --version
 ```
 
-## 1. Set Up Credentials
+## 1. Set up credentials
 
 Before connecting to Portal, export your credentials:
 
@@ -21,6 +21,8 @@ export ARCGIS_USERNAME=your_username
 export ARCGIS_PASSWORD=your_password
 ```
 
+If your environment already uses `PORTAL_USER` / `PORTAL_PASSWORD`, Git-Map accepts those aliases too.
+
 Or copy the example env file and edit it:
 
 ```bash
@@ -28,7 +30,15 @@ cp configs/env.example .env
 # edit .env with your credentials
 ```
 
-## 2. Clone an Existing Map
+## 2. Run a quick health check
+
+```bash
+gitmap doctor
+```
+
+This catches missing credentials or common environment problems before you start cloning maps.
+
+## 3. Clone an existing map
 
 The quickest way to start is cloning a map directly from Portal:
 
@@ -41,7 +51,7 @@ Replace `abc123def456` with your web map's item ID (visible in the Portal URL).
 
 This creates a local repository with the map's current state as the initial commit.
 
-## 3. Check Status
+## 4. Check status
 
 ```bash
 gitmap status
@@ -56,7 +66,7 @@ Expected output:
 Nothing to commit, working tree clean
 ```
 
-## 4. Create a Branch and Experiment
+## 5. Create a branch and experiment
 
 ```bash
 gitmap branch feature/new-basemap
@@ -70,7 +80,7 @@ gitmap pull
 gitmap status
 ```
 
-## 5. Commit Your Changes
+## 6. Commit your changes
 
 ```bash
 gitmap commit -m "Switched to dark basemap"
@@ -88,7 +98,7 @@ Created commit a3f2c1b0
 Branch 'feature/new-basemap' updated to a3f2c1b0
 ```
 
-## 6. Review What Changed
+## 7. Review what changed
 
 ```bash
 gitmap diff --branch main
@@ -96,13 +106,7 @@ gitmap diff --branch main
 
 Shows a layer-by-layer comparison between your feature branch and `main`.
 
-## 7. View History
-
-```bash
-gitmap log --oneline
-```
-
-## 8. Merge and Deploy
+## 8. Merge and deploy
 
 When the feature looks good, merge it back to `main` and push:
 

--- a/packages/gitmap_core/tests/test_cli_registration.py
+++ b/packages/gitmap_core/tests/test_cli_registration.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 # Ensure the CLI package is importable as 'gitmap_cli'
 # The package dir is named 'gitmap' but the package name is 'gitmap_cli' (via pyproject.toml mapping)
 # When not pip-installed, we register it manually as a module alias
+import os
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -140,6 +142,59 @@ class TestCommandRegistration:
         assert result.exit_code == 0
         assert "Usage: gitmap [OPTIONS] COMMAND [ARGS]..." in result.output
         assert "Usage: cli [OPTIONS] COMMAND [ARGS]..." not in result.output
+
+
+    def test_direct_script_help_uses_gitmap_prog_name(self) -> None:
+        """Running the source script directly should still present the public gitmap command name."""
+        repo_root = Path(__file__).resolve().parents[3]
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                [
+                    str(repo_root / "packages"),
+                    str(repo_root / "apps" / "cli" / "gitmap"),
+                ]
+            ),
+        }
+
+        result = subprocess.run(
+            [sys.executable, str(repo_root / "apps" / "cli" / "gitmap" / "main.py"), "--help"],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert "Usage: gitmap [OPTIONS] COMMAND [ARGS]..." in result.stdout
+        assert "Usage: main.py [OPTIONS] COMMAND [ARGS]..." not in result.stdout
+
+    def test_direct_script_unknown_command_points_to_gitmap_help(self) -> None:
+        """Source-script errors should point users at gitmap help, not main.py help."""
+        repo_root = Path(__file__).resolve().parents[3]
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                [
+                    str(repo_root / "packages"),
+                    str(repo_root / "apps" / "cli" / "gitmap"),
+                ]
+            ),
+        }
+
+        result = subprocess.run(
+            [sys.executable, str(repo_root / "apps" / "cli" / "gitmap" / "main.py"), "mergefrom"],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        combined_output = result.stdout + result.stderr
+        assert "Try 'gitmap --help' for help." in combined_output
+        assert "Run 'gitmap --help' to see the full command list." in combined_output
+        assert "Try 'main.py --help' for help." not in combined_output
 
     @pytest.mark.parametrize(
         ("mistyped", "expected"),

--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RELEASE_CHECKS_PATH = REPO_ROOT / "scripts/release_checks.py"
@@ -54,3 +56,60 @@ def test_release_metadata_requires_existing_readmes_and_typed_markers() -> None:
     release_checks._validate_package_metadata(release_checks.ROOT_PYPROJECT)
     release_checks._validate_package_metadata(release_checks.CORE_PYPROJECT)
     release_checks._validate_package_metadata(release_checks.CLI_PYPROJECT)
+
+
+@pytest.mark.parametrize(
+    ("ref_name", "expected_version"),
+    [
+        ("refs/tags/core-v1.2.3", "1.2.3"),
+        ("cli-v1.2.3", "1.2.3"),
+        ("v1.2.3", "1.2.3"),
+    ],
+)
+def test_validate_release_tag_accepts_matching_tags(ref_name: str, expected_version: str) -> None:
+    release_checks = _load_release_checks_module()
+
+    release_checks.validate_release_tag(
+        ref_name,
+        state={
+            "root_version": expected_version,
+            "core_version": expected_version,
+            "cli_version": expected_version,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("ref_name", "state", "message"),
+    [
+        (
+            "refs/tags/core-v9.9.9",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "expected version 1.2.3",
+        ),
+        (
+            "cli-v2.0.0",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "expected version 1.2.3",
+        ),
+        (
+            "v0.0.1",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "expected version 1.2.3",
+        ),
+        (
+            "refs/heads/main",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "Release tag must be one of",
+        ),
+    ],
+)
+def test_validate_release_tag_rejects_mismatched_or_invalid_tags(
+    ref_name: str,
+    state: dict[str, str],
+    message: str,
+) -> None:
+    release_checks = _load_release_checks_module()
+
+    with pytest.raises(AssertionError, match=message):
+        release_checks.validate_release_tag(ref_name, state=state)

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -108,6 +109,28 @@ def _validate_package_metadata(pyproject: Path) -> None:
             )
 
 
+def validate_release_tag(ref_name: str, state: dict[str, str | list[str]] | None = None) -> None:
+    normalized_ref = ref_name.removeprefix("refs/tags/")
+    tag_match = re.fullmatch(r"(?:(core|cli)-)?v(.+)", normalized_ref)
+    assert tag_match, (
+        "Release tag must be one of core-v<version>, cli-v<version>, or v<version>: "
+        f"{ref_name}"
+    )
+
+    package_prefix, tag_version = tag_match.groups()
+    state = state or collect_release_state()
+    expected_versions = {
+        None: state["root_version"],
+        "core": state["core_version"],
+        "cli": state["cli_version"],
+    }
+    expected_version = expected_versions[package_prefix]
+    assert tag_version == expected_version, (
+        f"Release tag {normalized_ref} does not match expected version {expected_version}"
+    )
+
+
+
 def validate_release_state() -> None:
     state = collect_release_state()
     versions = {
@@ -153,7 +176,20 @@ def validate_release_state() -> None:
         assert expected_command in ci_workflow_text, f"CI workflow missing packaging command: {expected_command}"
 
 
-if __name__ == "__main__":
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ref-name", help="Git ref/tag name to validate against release metadata")
+    args = parser.parse_args()
+
     validate_release_state()
     state = collect_release_state()
+    if args.ref_name:
+        validate_release_tag(args.ref_name, state=state)
+        print(f"Release metadata OK for {args.ref_name} (GitMap v{state['root_version']})")
+        return
+
     print(f"Release metadata OK for GitMap v{state['root_version']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- align README and getting-started docs around the preferred `ARCGIS_USERNAME` / `ARCGIS_PASSWORD` setup
- improve install instructions with explicit version verification, venv-based source install, and first-run checks
- update the sample `.env` file and quickstart flow to include `gitmap doctor` before clone/push workflows

## Testing
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests integrations/openclaw/tests -x -q`
