### PR TITLE
fix: restore Git-Map CI after README merge

### DIFF
--- a/apps/cli/gitmap/main.py
+++ b/apps/cli/gitmap/main.py
@@ -19,7 +19,16 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+import types
 from pathlib import Path
+
+# Support direct source execution (`python apps/cli/gitmap/main.py`) in CI
+# before the CLI package itself is installed.
+if "gitmap_cli" not in sys.modules:
+    _pkg = types.ModuleType("gitmap_cli")
+    _pkg.__path__ = [str(Path(__file__).resolve().parent)]
+    _pkg.__package__ = "gitmap_cli"
+    sys.modules["gitmap_cli"] = _pkg
 
 import click
 from gitmap_cli.commands.auto_pull import auto_pull

--- a/packages/gitmap_core/tests/test_cli_error_messages.py
+++ b/packages/gitmap_core/tests/test_cli_error_messages.py
@@ -9,20 +9,20 @@ import pytest
 from click.testing import CliRunner
 
 _repo_root = Path(__file__).resolve().parents[3]
-_cli_dir = _repo_root / 'apps' / 'cli' / 'gitmap'
-_cli_commands_dir = _cli_dir / 'commands'
+_cli_dir = _repo_root / "apps" / "cli" / "gitmap"
+_cli_commands_dir = _cli_dir / "commands"
 
-if 'gitmap_cli' not in sys.modules:
-    _pkg = types.ModuleType('gitmap_cli')
+if "gitmap_cli" not in sys.modules:
+    _pkg = types.ModuleType("gitmap_cli")
     _pkg.__path__ = [str(_cli_dir)]
-    _pkg.__package__ = 'gitmap_cli'
-    sys.modules['gitmap_cli'] = _pkg
+    _pkg.__package__ = "gitmap_cli"
+    sys.modules["gitmap_cli"] = _pkg
 
-if 'gitmap_cli.commands' not in sys.modules:
-    _cmds = types.ModuleType('gitmap_cli.commands')
+if "gitmap_cli.commands" not in sys.modules:
+    _cmds = types.ModuleType("gitmap_cli.commands")
     _cmds.__path__ = [str(_cli_commands_dir)]
-    _cmds.__package__ = 'gitmap_cli.commands'
-    sys.modules['gitmap_cli.commands'] = _cmds
+    _cmds.__package__ = "gitmap_cli.commands"
+    sys.modules["gitmap_cli.commands"] = _cmds
 
 if str(_cli_dir) not in sys.path:
     sys.path.insert(0, str(_cli_dir))
@@ -39,17 +39,19 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-def test_branch_delete_without_name_surfaces_actionable_click_error(monkeypatch: pytest.MonkeyPatch, runner: CliRunner) -> None:
+def test_branch_delete_without_name_surfaces_actionable_click_error(
+    monkeypatch: pytest.MonkeyPatch, runner: CliRunner
+) -> None:
     repo = Mock()
-    repo.get_current_branch.return_value = 'main'
-    monkeypatch.setattr(branch_module, 'find_repository', lambda: repo)
+    repo.get_current_branch.return_value = "main"
+    monkeypatch.setattr(branch_module, "find_repository", lambda: repo)
 
-    result = runner.invoke(branch, ['--delete'])
+    result = runner.invoke(branch, ["--delete"])
 
     assert result.exit_code != 0
-    assert 'Branch name required.' in result.output
-    assert 'Usage: gitmap branch <name>' in result.output
-    assert 'Branch operation failed:' not in result.output
+    assert "Branch name required." in result.output
+    assert "Usage: gitmap branch <name>" in result.output
+    assert "Branch operation failed:" not in result.output
 
 
 def test_tag_without_name_surfaces_usage_instead_of_generic_wrapper(
@@ -57,10 +59,10 @@ def test_tag_without_name_surfaces_usage_instead_of_generic_wrapper(
     runner: CliRunner,
 ) -> None:
     repo = Mock()
-    monkeypatch.setattr(tag_module, 'find_repository', lambda: repo)
+    monkeypatch.setattr(tag_module, "find_repository", lambda: repo)
 
     result = runner.invoke(tag, [])
 
     assert result.exit_code != 0
-    assert 'Usage: gitmap tag <name> [commit] or gitmap tag --list' in result.output
-    assert 'Tag operation failed:' not in result.output
+    assert "Usage: gitmap tag <name> [commit] or gitmap tag --list" in result.output
+    assert "Tag operation failed:" not in result.output

--- a/packages/gitmap_core/tests/test_cli_registration.py
+++ b/packages/gitmap_core/tests/test_cli_registration.py
@@ -143,7 +143,6 @@ class TestCommandRegistration:
         assert "Usage: gitmap [OPTIONS] COMMAND [ARGS]..." in result.output
         assert "Usage: cli [OPTIONS] COMMAND [ARGS]..." not in result.output
 
-
     def test_direct_script_help_uses_gitmap_prog_name(self) -> None:
         """Running the source script directly should still present the public gitmap command name."""
         repo_root = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Summary
- apply ruff formatting to two CLI test files that broke the lint job
- make direct `python apps/cli/gitmap/main.py` execution resolve the source `gitmap_cli` package before editable CLI install

## Verification
- `python3 -m ruff check packages/gitmap_core/ apps/cli/gitmap/ --select E,F,B,W --ignore E501,E741,F841,W293`
- `python3 -m ruff format --check packages/gitmap_core/ apps/cli/gitmap/`
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests/test_cli_registration.py packages/gitmap_core/tests/test_cli_error_messages.py -q` (`15 passed`)
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests integrations/openclaw/tests -q` (`808 passed`)

Granite/Barkie untouched.