### PR TITLE
docs: polish GitMap landing page

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -4,419 +4,766 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>GitMap — Version Control for ArcGIS Web Maps</title>
-  <meta name="description" content="GitMap brings Git-like version control to ArcGIS Online and Enterprise Portal. Branch, commit, diff, merge, and revert your web maps." />
+  <meta name="description" content="GitMap brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. Branch, commit, diff, merge, review, and safely release map changes." />
   <meta property="og:title" content="GitMap — Version Control for ArcGIS Web Maps" />
-  <meta property="og:description" content="Branch, commit, diff, merge, and revert ArcGIS web maps. Open source. Free." />
+  <meta property="og:description" content="Branch, commit, diff, merge, and revert ArcGIS web maps with workflows GIS teams already understand." />
   <meta property="og:url" content="https://ingramgeoai.com/gitmap" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
     :root {
-      --bg: #0a0e1a;
+      --bg: #0b1220;
       --surface: #111827;
-      --border: #1e2d40;
-      --accent: #3b82f6;
-      --accent2: #10b981;
-      --text: #e2e8f0;
-      --muted: #64748b;
+      --surface-2: #162132;
+      --border: #23324a;
+      --accent: #60a5fa;
+      --accent-strong: #3b82f6;
+      --accent-soft: rgba(96, 165, 250, 0.12);
+      --success: #34d399;
+      --warning: #fbbf24;
+      --danger: #f87171;
+      --text: #e5eefb;
+      --muted: #94a3b8;
       --code-bg: #0d1117;
-      --font-mono: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+      --shadow: 0 24px 64px rgba(0, 0, 0, 0.45);
+      --font-mono: 'Cascadia Code', 'Fira Code', 'SFMono-Regular', 'Consolas', monospace;
     }
 
     html { scroll-behavior: smooth; }
 
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      background: var(--bg);
+      background:
+        radial-gradient(circle at top, rgba(59,130,246,0.18), transparent 35%),
+        linear-gradient(180deg, #0a0f1c 0%, #0b1220 100%);
       color: var(--text);
-      line-height: 1.6;
+      line-height: 1.65;
     }
 
-    /* NAV */
+    a { color: inherit; }
+
     nav {
-      position: sticky; top: 0; z-index: 100;
-      background: rgba(10, 14, 26, 0.92);
-      backdrop-filter: blur(12px);
-      border-bottom: 1px solid var(--border);
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      height: 64px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
       padding: 0 2rem;
-      display: flex; align-items: center; justify-content: space-between;
-      height: 60px;
+      background: rgba(11, 18, 32, 0.88);
+      backdrop-filter: blur(14px);
+      border-bottom: 1px solid rgba(35, 50, 74, 0.9);
     }
-    .nav-logo { font-weight: 700; font-size: 1.1rem; color: var(--accent); letter-spacing: -0.02em; }
-    .nav-links { display: flex; gap: 1.5rem; }
-    .nav-links a { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color .2s; }
-    .nav-links a:hover { color: var(--text); }
-    .nav-cta {
-      background: var(--accent); color: #fff; padding: 0.4rem 1rem;
-      border-radius: 6px; text-decoration: none; font-size: 0.85rem; font-weight: 600;
-      transition: background .2s;
-    }
-    .nav-cta:hover { background: #2563eb; }
 
-    /* HERO */
-    .hero {
-      max-width: 960px; margin: 0 auto;
-      padding: 6rem 2rem 4rem;
-      text-align: center;
+    .nav-logo {
+      font-weight: 800;
+      font-size: 1.05rem;
+      letter-spacing: -0.02em;
+      color: var(--accent);
     }
+
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 1.4rem;
+    }
+
+    .nav-links a {
+      text-decoration: none;
+      color: var(--muted);
+      font-size: 0.92rem;
+      transition: color 0.2s ease;
+    }
+
+    .nav-links a:hover { color: var(--text); }
+
+    .nav-cta {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0.48rem 1rem;
+      border-radius: 999px;
+      text-decoration: none;
+      font-size: 0.86rem;
+      font-weight: 700;
+      color: white;
+      background: linear-gradient(135deg, var(--accent-strong), #2563eb);
+      box-shadow: 0 10px 24px rgba(37, 99, 235, 0.28);
+    }
+
+    .hero {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 5.5rem 2rem 4rem;
+      display: grid;
+      grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+      gap: 2rem;
+      align-items: center;
+    }
+
+    .hero-copy { max-width: 620px; }
+
     .hero-badge {
-      display: inline-block;
-      background: rgba(59, 130, 246, 0.12);
-      border: 1px solid rgba(59, 130, 246, 0.3);
+      display: inline-flex;
+      align-items: center;
+      gap: 0.55rem;
+      background: var(--accent-soft);
+      border: 1px solid rgba(96, 165, 250, 0.28);
       color: var(--accent);
       border-radius: 999px;
-      padding: 0.3rem 0.9rem;
-      font-size: 0.78rem;
-      font-weight: 600;
+      padding: 0.38rem 0.9rem;
+      font-size: 0.8rem;
+      font-weight: 700;
       letter-spacing: 0.04em;
       text-transform: uppercase;
+      margin-bottom: 1.25rem;
+    }
+
+    h1 {
+      font-size: clamp(2.5rem, 5vw, 4.35rem);
+      line-height: 1.02;
+      font-weight: 850;
+      letter-spacing: -0.045em;
+      margin-bottom: 1.2rem;
+    }
+
+    .hero-sub {
+      color: var(--muted);
+      font-size: 1.12rem;
+      max-width: 560px;
+      margin-bottom: 1.6rem;
+    }
+
+    .hero-proof {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.7rem;
+      margin-bottom: 1.8rem;
+    }
+
+    .proof-pill {
+      padding: 0.42rem 0.72rem;
+      border-radius: 999px;
+      background: rgba(17, 24, 39, 0.9);
+      border: 1px solid var(--border);
+      color: #cbd5e1;
+      font-size: 0.84rem;
+    }
+
+    .hero-actions {
+      display: flex;
+      gap: 0.9rem;
+      flex-wrap: wrap;
       margin-bottom: 1.5rem;
     }
-    h1 {
-      font-size: clamp(2.2rem, 5vw, 3.6rem);
-      font-weight: 800;
-      line-height: 1.1;
-      letter-spacing: -0.03em;
-      margin-bottom: 1.25rem;
-      background: linear-gradient(135deg, #e2e8f0 0%, #94a3b8 100%);
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      background-clip: text;
-    }
-    .hero-sub {
-      font-size: 1.15rem;
-      color: var(--muted);
-      max-width: 560px;
-      margin: 0 auto 2.5rem;
-    }
-    .hero-actions { display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
-    .btn-primary {
-      background: var(--accent); color: #fff;
-      padding: 0.75rem 1.75rem; border-radius: 8px;
-      text-decoration: none; font-weight: 700; font-size: 1rem;
-      transition: background .2s, transform .15s;
-    }
-    .btn-primary:hover { background: #2563eb; transform: translateY(-1px); }
-    .btn-secondary {
-      background: transparent; color: var(--text);
-      padding: 0.75rem 1.75rem; border-radius: 8px;
-      text-decoration: none; font-weight: 600; font-size: 1rem;
-      border: 1px solid var(--border);
-      transition: border-color .2s, transform .15s;
-    }
-    .btn-secondary:hover { border-color: var(--accent); transform: translateY(-1px); }
 
-    /* TERMINAL DEMO */
-    .terminal-wrap {
-      max-width: 760px; margin: 3rem auto 0;
-      border-radius: 12px; overflow: hidden;
+    .btn-primary, .btn-secondary {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 48px;
+      padding: 0.8rem 1.35rem;
+      border-radius: 12px;
+      text-decoration: none;
+      font-weight: 700;
+      transition: transform 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, var(--accent-strong), #2563eb);
+      color: white;
+      box-shadow: 0 14px 28px rgba(37, 99, 235, 0.24);
+    }
+
+    .btn-primary:hover, .btn-secondary:hover { transform: translateY(-1px); }
+
+    .btn-secondary {
+      color: var(--text);
       border: 1px solid var(--border);
-      box-shadow: 0 24px 64px rgba(0,0,0,0.5);
+      background: rgba(17, 24, 39, 0.72);
     }
-    .terminal-bar {
-      background: #1a1f2e; padding: 0.6rem 1rem;
-      display: flex; align-items: center; gap: 0.5rem;
+
+    .hero-note {
+      color: var(--muted);
+      font-size: 0.92rem;
     }
-    .dot { width: 12px; height: 12px; border-radius: 50%; }
-    .dot-red { background: #ff5f57; }
-    .dot-yellow { background: #ffbd2e; }
-    .dot-green { background: #28c940; }
-    .terminal-title { flex: 1; text-align: center; font-size: 0.75rem; color: var(--muted); }
-    .terminal-body {
-      background: var(--code-bg);
-      padding: 1.5rem;
+
+    .hero-note code {
       font-family: var(--font-mono);
-      font-size: 0.85rem;
-      line-height: 1.8;
+      color: #cfe6ff;
     }
+
+    .hero-card,
+    .card,
+    .step,
+    .faq-item,
+    .audience-card,
+    .metric-card {
+      background: linear-gradient(180deg, rgba(17,24,39,0.94), rgba(13,17,23,0.98));
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: var(--shadow);
+    }
+
+    .hero-card {
+      padding: 1.1rem;
+    }
+
+    .terminal-wrap {
+      border-radius: 16px;
+      overflow: hidden;
+      border: 1px solid rgba(35, 50, 74, 0.95);
+      background: var(--code-bg);
+    }
+
+    .terminal-bar {
+      padding: 0.75rem 1rem;
+      background: #171f2f;
+      display: flex;
+      align-items: center;
+      gap: 0.55rem;
+      border-bottom: 1px solid rgba(35, 50, 74, 0.9);
+    }
+
+    .dot { width: 11px; height: 11px; border-radius: 50%; }
+    .dot-red { background: #ff5f57; }
+    .dot-yellow { background: #febc2e; }
+    .dot-green { background: #28c840; }
+
+    .terminal-title {
+      margin-left: auto;
+      font-size: 0.76rem;
+      color: var(--muted);
+    }
+
+    .terminal-body {
+      padding: 1.25rem;
+      font-family: var(--font-mono);
+      font-size: 0.84rem;
+      line-height: 1.8;
+      color: #d6e4f3;
+    }
+
     .cmd { color: #7dd3fc; }
     .out { color: #94a3b8; }
-    .hi { color: #4ade80; }
-    .hi2 { color: #fbbf24; }
-    .hi3 { color: #f87171; }
+    .plus { color: var(--success); }
+    .minus { color: var(--danger); }
+    .tilde { color: var(--warning); }
 
-    /* SECTION */
-    section { max-width: 960px; margin: 0 auto; padding: 5rem 2rem; }
-    .section-label {
-      font-size: 0.78rem; font-weight: 700; letter-spacing: 0.1em;
-      text-transform: uppercase; color: var(--accent);
-      margin-bottom: 0.75rem;
-    }
-    h2 {
-      font-size: clamp(1.6rem, 3.5vw, 2.4rem);
-      font-weight: 800; letter-spacing: -0.02em;
-      margin-bottom: 1rem;
-    }
-    .section-desc { color: var(--muted); font-size: 1.05rem; max-width: 520px; margin-bottom: 3rem; }
-
-    /* WHY TABLE */
-    .why-grid {
+    .side-panel {
+      margin-top: 1rem;
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 1rem;
+      gap: 0.9rem;
     }
-    .why-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 1.5rem;
-      transition: border-color .2s;
-    }
-    .why-card:hover { border-color: var(--accent); }
-    .why-problem { color: var(--muted); font-size: 0.85rem; margin-bottom: 0.5rem; font-style: italic; }
-    .why-solution { font-weight: 600; font-size: 0.95rem; }
-    .why-cmd { font-family: var(--font-mono); color: var(--accent); font-size: 0.8rem; margin-top: 0.4rem; }
 
-    /* FEATURES */
-    .features-grid {
+    .metric-card {
+      padding: 1rem 1.1rem;
+      display: grid;
+      gap: 0.25rem;
+    }
+
+    .metric-label {
+      font-size: 0.76rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--accent);
+      font-weight: 700;
+    }
+
+    .metric-value {
+      font-size: 1.4rem;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+    }
+
+    .metric-copy {
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .divider {
+      max-width: 1120px;
+      margin: 0 auto;
+      border: none;
+      border-top: 1px solid rgba(35, 50, 74, 0.75);
+    }
+
+    section {
+      max-width: 1120px;
+      margin: 0 auto;
+      padding: 4.5rem 2rem;
+    }
+
+    .section-label {
+      font-size: 0.8rem;
+      font-weight: 800;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 0.8rem;
+    }
+
+    h2 {
+      font-size: clamp(1.75rem, 3.4vw, 2.75rem);
+      line-height: 1.08;
+      letter-spacing: -0.03em;
+      margin-bottom: 1rem;
+      font-weight: 800;
+    }
+
+    .section-desc {
+      max-width: 680px;
+      color: var(--muted);
+      font-size: 1.04rem;
+      margin-bottom: 2rem;
+    }
+
+    .card-grid,
+    .audience-grid,
+    .faq-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-      gap: 1.5rem;
+      gap: 1rem;
     }
-    .feature-card {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 1.5rem;
-    }
-    .feature-icon { font-size: 1.6rem; margin-bottom: 0.75rem; }
-    .feature-title { font-weight: 700; margin-bottom: 0.4rem; }
-    .feature-desc { color: var(--muted); font-size: 0.9rem; }
 
-    /* INSTALL */
+    .card,
+    .audience-card,
+    .faq-item,
+    .step {
+      padding: 1.35rem;
+    }
+
+    .card h3,
+    .audience-card h3,
+    .faq-item h3,
+    .step h3 {
+      margin-bottom: 0.6rem;
+      font-size: 1.05rem;
+      letter-spacing: -0.02em;
+    }
+
+    .card p,
+    .audience-card p,
+    .faq-item p,
+    .step p,
+    .step li {
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .card code,
+    .step code,
+    .faq-item code,
+    .audience-card code {
+      font-family: var(--font-mono);
+      color: #cfe6ff;
+      font-size: 0.88em;
+    }
+
+    .steps {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      margin-top: 1.5rem;
+    }
+
+    .step-number {
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--accent-soft);
+      border: 1px solid rgba(96, 165, 250, 0.3);
+      color: var(--accent);
+      font-size: 0.9rem;
+      font-weight: 800;
+      margin-bottom: 0.9rem;
+    }
+
+    .install-shell {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 320px;
+      gap: 1rem;
+      align-items: start;
+    }
+
     .install-block {
       background: var(--code-bg);
       border: 1px solid var(--border);
-      border-radius: 10px;
-      padding: 1.5rem 2rem;
+      border-radius: 18px;
+      padding: 1.4rem 1.5rem;
       font-family: var(--font-mono);
-      font-size: 0.9rem;
-      line-height: 2;
-      max-width: 640px;
+      font-size: 0.92rem;
+      line-height: 1.85;
+      overflow-x: auto;
     }
+
     .install-comment { color: var(--muted); }
     .install-cmd { color: #7dd3fc; }
 
-    /* BADGES */
-    .badges { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 2rem; }
-    .badges img { height: 20px; }
-
-    /* FOOTER */
-    footer {
-      border-top: 1px solid var(--border);
-      text-align: center;
-      padding: 2.5rem 1rem;
-      color: var(--muted);
-      font-size: 0.85rem;
+    .install-side {
+      display: grid;
+      gap: 1rem;
     }
-    footer a { color: var(--accent); text-decoration: none; }
+
+    .badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem;
+    }
+
+    .badges img {
+      height: 22px;
+      border-radius: 999px;
+    }
+
+    ul.clean {
+      list-style: none;
+      display: grid;
+      gap: 0.65rem;
+      margin-top: 0.6rem;
+    }
+
+    ul.clean li::before {
+      content: "•";
+      color: var(--accent);
+      font-weight: 700;
+      margin-right: 0.55rem;
+    }
+
+    .cta {
+      max-width: 1120px;
+      margin: 0 auto 4rem;
+      padding: 0 2rem;
+    }
+
+    .cta-card {
+      padding: 2rem;
+      border-radius: 22px;
+      border: 1px solid rgba(96, 165, 250, 0.28);
+      background:
+        linear-gradient(135deg, rgba(37,99,235,0.16), rgba(17,24,39,0.94)),
+        linear-gradient(180deg, rgba(17,24,39,0.96), rgba(13,17,23,0.98));
+      box-shadow: var(--shadow);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    .cta-copy h2 {
+      margin-bottom: 0.6rem;
+      font-size: clamp(1.6rem, 3vw, 2.35rem);
+    }
+
+    .cta-copy p {
+      color: #c6d4e3;
+      max-width: 640px;
+    }
+
+    footer {
+      border-top: 1px solid rgba(35, 50, 74, 0.75);
+      padding: 2.5rem 1rem 3rem;
+      text-align: center;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
+    footer a {
+      color: var(--accent);
+      text-decoration: none;
+    }
+
     footer a:hover { text-decoration: underline; }
 
-    /* DIVIDER */
-    .divider { border: none; border-top: 1px solid var(--border); }
+    @media (max-width: 940px) {
+      .hero,
+      .install-shell {
+        grid-template-columns: 1fr;
+      }
+    }
 
-    @media (max-width: 600px) {
+    @media (max-width: 700px) {
       nav { padding: 0 1rem; }
       .nav-links { display: none; }
+      .hero, section { padding-left: 1rem; padding-right: 1rem; }
+      .cta { padding: 0 1rem; }
+      .cta-card { padding: 1.4rem; }
     }
   </style>
 </head>
 <body>
+  <nav>
+    <span class="nav-logo">🗺 GitMap</span>
+    <div class="nav-links">
+      <a href="#problem">Problem</a>
+      <a href="#workflow">Workflow</a>
+      <a href="#install">Install</a>
+      <a href="#faq">FAQ</a>
+      <a href="https://14-tr.github.io/Git-Map/" target="_blank" rel="noreferrer">Docs</a>
+      <a href="https://github.com/14-TR/Git-Map" target="_blank" rel="noreferrer">GitHub</a>
+    </div>
+    <a class="nav-cta" href="#install">Get Started</a>
+  </nav>
 
-<!-- NAV -->
-<nav>
-  <span class="nav-logo">🗺 GitMap</span>
-  <div class="nav-links">
-    <a href="#why">Why</a>
-    <a href="#features">Features</a>
-    <a href="#install">Install</a>
-    <a href="https://14-tr.github.io/Git-Map/" target="_blank">Docs</a>
-    <a href="https://github.com/14-TR/Git-Map" target="_blank">GitHub</a>
-  </div>
-  <a class="nav-cta" href="#install">Get Started</a>
-</nav>
+  <div class="hero">
+    <div class="hero-copy">
+      <div class="hero-badge">Open source · MIT · Built for ArcGIS Online &amp; Enterprise</div>
+      <h1>Version control for ArcGIS web maps.</h1>
+      <p class="hero-sub">
+        GitMap gives GIS teams a safer way to ship map changes: clone a map, branch for experiments,
+        review diffs, merge intentionally, and push only when you're ready.
+      </p>
+      <div class="hero-proof">
+        <span class="proof-pill">Git-style CLI that feels familiar</span>
+        <span class="proof-pill">734+ tests in the main repo</span>
+        <span class="proof-pill">Works with Python 3.11–3.14</span>
+        <span class="proof-pill">Command docs and workflow guides included</span>
+      </div>
+      <div class="hero-actions">
+        <a class="btn-primary" href="#install">pip install gitmap</a>
+        <a class="btn-secondary" href="https://14-tr.github.io/Git-Map/" target="_blank" rel="noreferrer">Read the docs →</a>
+      </div>
+      <p class="hero-note">Start with <code>gitmap clone &lt;item-id&gt;</code> for an existing web map or <code>gitmap init</code> for a new repo.</p>
+    </div>
 
-<!-- HERO -->
-<div class="hero">
-  <div class="hero-badge">Open Source · MIT License</div>
-  <h1>Git for your<br/>ArcGIS web maps.</h1>
-  <p class="hero-sub">
-    Branch, commit, diff, merge, and revert ArcGIS Online &amp; Portal web maps
-    with the workflows your team already knows.
-  </p>
-  <div class="hero-actions">
-    <a class="btn-primary" href="#install">pip install gitmap</a>
-    <a class="btn-secondary" href="https://github.com/14-TR/Git-Map" target="_blank">View on GitHub →</a>
-  </div>
+    <div class="hero-card">
+      <div class="terminal-wrap">
+        <div class="terminal-bar">
+          <div class="dot dot-red"></div>
+          <div class="dot dot-yellow"></div>
+          <div class="dot dot-green"></div>
+          <span class="terminal-title">gitmap workflow</span>
+        </div>
+        <div class="terminal-body">
+          <div><span class="cmd">$ gitmap clone a1b2c3d4e5f6</span></div>
+          <div><span class="plus">Cloned "County Flood Risk" into county-flood-risk</span></div>
+          <br />
+          <div><span class="cmd">$ gitmap branch feature/hydrants</span></div>
+          <div><span class="plus">Created branch feature/hydrants</span></div>
+          <br />
+          <div><span class="cmd">$ gitmap diff main feature/hydrants</span></div>
+          <div><span class="tilde">~ operationalLayers[2].visibility: false -&gt; true</span></div>
+          <div><span class="plus">+ operationalLayers[5]: "Hydrants"</span></div>
+          <br />
+          <div><span class="cmd">$ gitmap commit -m "Add hydrants layer"</span></div>
+          <div><span class="plus">[feature/hydrants 8f2a1d9] Add hydrants layer</span></div>
+          <br />
+          <div><span class="cmd">$ gitmap push --branch feature/hydrants</span></div>
+          <div><span class="out">Pushed feature/hydrants to Portal</span></div>
+        </div>
+      </div>
 
-  <!-- Terminal demo -->
-  <div class="terminal-wrap">
-    <div class="terminal-bar">
-      <div class="dot dot-red"></div>
-      <div class="dot dot-yellow"></div>
-      <div class="dot dot-green"></div>
-      <span class="terminal-title">gitmap demo</span>
-    </div>
-    <div class="terminal-body">
-      <div><span class="cmd">$ gitmap init --portal https://gis.myorg.com/portal --item-id abc123</span></div>
-      <div><span class="hi">✔ Initialized GitMap repo for "Flood Risk Assessment"</span></div>
-      <br/>
-      <div><span class="cmd">$ gitmap commit -m "Added FEMA flood zones layer"</span></div>
-      <div><span class="hi">[main 3d7f1a2] Added FEMA flood zones layer</span></div>
-      <div><span class="out">  1 layer added, 2 properties changed</span></div>
-      <br/>
-      <div><span class="cmd">$ gitmap branch feature/new-basemap && gitmap checkout feature/new-basemap</span></div>
-      <div><span class="hi">✔ Switched to branch 'feature/new-basemap'</span></div>
-      <br/>
-      <div><span class="cmd">$ gitmap diff --branch main</span></div>
-      <div><span class="hi2">~ Layer: Topographic Basemap</span></div>
-      <div><span class="hi3">  - style: "streets-v12"</span></div>
-      <div><span class="hi">  + style: "satellite-streets-v12"</span></div>
-      <br/>
-      <div><span class="cmd">$ gitmap merge feature/new-basemap</span></div>
-      <div><span class="hi">✔ Merged feature/new-basemap → main</span></div>
-    </div>
-  </div>
-</div>
-
-<hr class="divider"/>
-
-<!-- WHY SECTION -->
-<section id="why">
-  <div class="section-label">Why GitMap</div>
-  <h2>Every GIS team has these problems.</h2>
-  <p class="section-desc">GitMap solves the version control gap that's been missing from ArcGIS workflows since the beginning.</p>
-
-  <div class="why-grid">
-    <div class="why-card">
-      <div class="why-problem">"Who changed the basemap last Tuesday?"</div>
-      <div class="why-solution">Full commit history with author, timestamp, and message.</div>
-      <div class="why-cmd">gitmap log</div>
-    </div>
-    <div class="why-card">
-      <div class="why-problem">"I need to test this symbology without breaking production."</div>
-      <div class="why-solution">Isolated branches — experiment freely, merge when ready.</div>
-      <div class="why-cmd">gitmap branch feature/symbology</div>
-    </div>
-    <div class="why-card">
-      <div class="why-problem">"Revert the map to last week's state."</div>
-      <div class="why-solution">Checkout any previous commit instantly.</div>
-      <div class="why-cmd">gitmap checkout &lt;commit-id&gt;</div>
-    </div>
-    <div class="why-card">
-      <div class="why-problem">"What's different between staging and production?"</div>
-      <div class="why-solution">Layer-by-layer visual diff between any two branches.</div>
-      <div class="why-cmd">gitmap diff --branch production</div>
-    </div>
-    <div class="why-card">
-      <div class="why-problem">"Keep 50 maps in sync with Portal changes."</div>
-      <div class="why-solution">Auto-pull tracks remote map state and syncs on schedule.</div>
-      <div class="why-cmd">gitmap auto-pull</div>
-    </div>
-    <div class="why-card">
-      <div class="why-problem">"Share map state between team members."</div>
-      <div class="why-solution">Push/pull to shared Portal items like a Git remote.</div>
-      <div class="why-cmd">gitmap push origin main</div>
+      <div class="side-panel">
+        <div class="metric-card">
+          <div class="metric-label">Why it matters</div>
+          <div class="metric-value">No more “who changed the map?”</div>
+          <div class="metric-copy">Get a readable audit trail instead of guessing from Portal timestamps.</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-label">Release safety</div>
+          <div class="metric-value">Review before you overwrite prod</div>
+          <div class="metric-copy">Diffs, branches, merge points, and revert flows give map releases a real safety net.</div>
+        </div>
+      </div>
     </div>
   </div>
-</section>
 
-<hr class="divider"/>
+  <hr class="divider" />
 
-<!-- FEATURES SECTION -->
-<section id="features">
-  <div class="section-label">Features</div>
-  <h2>Everything you'd expect from Git,<br/>built for GIS.</h2>
-  <p class="section-desc">Works with ArcGIS Online and Enterprise Portal. Python 3.11–3.13. 450+ tests. MIT licensed.</p>
+  <section id="problem">
+    <div class="section-label">Problem</div>
+    <h2>ArcGIS web maps are collaborative, but the release workflow usually isn't.</h2>
+    <p class="section-desc">
+      Teams change basemaps, layers, symbology, popups, and extent settings every week. Without version control,
+      those edits are hard to review, risky to test, and painful to roll back.
+    </p>
 
-  <div class="features-grid">
-    <div class="feature-card">
-      <div class="feature-icon">🌿</div>
-      <div class="feature-title">Branching</div>
-      <div class="feature-desc">Create isolated branches to safely develop and test map changes without touching production.</div>
+    <div class="card-grid">
+      <div class="card">
+        <h3>“What changed?”</h3>
+        <p>Portal tells you something was modified. GitMap shows the exact properties, layers, and settings that changed.</p>
+      </div>
+      <div class="card">
+        <h3>“Can I test this safely?”</h3>
+        <p>Create a branch for experiments, staging updates, or stakeholder review before anything touches production.</p>
+      </div>
+      <div class="card">
+        <h3>“Can we undo it?”</h3>
+        <p>Use <code>gitmap revert</code>, branch history, and commit snapshots to recover from bad releases without guesswork.</p>
+      </div>
+      <div class="card">
+        <h3>“How do we compare environments?”</h3>
+        <p>Diff branches or commits to review staging vs production map state before you publish.</p>
+      </div>
     </div>
-    <div class="feature-card">
-      <div class="feature-icon">📝</div>
-      <div class="feature-title">Commits &amp; History</div>
-      <div class="feature-desc">Save named snapshots with messages. Full log with author, date, and what changed.</div>
+  </section>
+
+  <hr class="divider" />
+
+  <section id="workflow">
+    <div class="section-label">Workflow</div>
+    <h2>A Git-shaped workflow for map configuration.</h2>
+    <p class="section-desc">
+      GitMap doesn't try to reinvent release discipline. It adapts the familiar Git loop to ArcGIS web map JSON so GIS teams can work more intentionally.
+    </p>
+
+    <div class="steps">
+      <div class="step">
+        <div class="step-number">1</div>
+        <h3>Clone or initialize</h3>
+        <p>Pull down an existing web map with <code>gitmap clone</code> or start a new repository with <code>gitmap init</code>.</p>
+      </div>
+      <div class="step">
+        <div class="step-number">2</div>
+        <h3>Branch for changes</h3>
+        <p>Use branches to isolate basemap swaps, popup edits, symbology experiments, or release prep work.</p>
+      </div>
+      <div class="step">
+        <div class="step-number">3</div>
+        <h3>Review diffs</h3>
+        <p>Check exactly what changed before you commit or merge. No more comparing screenshots and memory.</p>
+      </div>
+      <div class="step">
+        <div class="step-number">4</div>
+        <h3>Merge and push</h3>
+        <p>Promote approved changes back to the main branch and sync them to ArcGIS Online or Portal.</p>
+      </div>
     </div>
-    <div class="feature-card">
-      <div class="feature-icon">🔍</div>
-      <div class="feature-title">Visual Diff</div>
-      <div class="feature-desc">See exactly what changed between any two commits or branches — layers, opacity, visibility, symbology.</div>
+  </section>
+
+  <hr class="divider" />
+
+  <section id="audience">
+    <div class="section-label">Who it's for</div>
+    <h2>Built for the people who carry map changes into production.</h2>
+    <p class="section-desc">GitMap is especially useful when more than one person touches the same web map, or when production updates need review.</p>
+
+    <div class="audience-grid">
+      <div class="audience-card">
+        <h3>GIS analysts</h3>
+        <p>Track layer configuration, popup edits, and map behavior over time without needing a custom audit workflow.</p>
+      </div>
+      <div class="audience-card">
+        <h3>GIS developers</h3>
+        <p>Use a familiar CLI, scriptable workflows, and repository-style history for repeatable deployments.</p>
+      </div>
+      <div class="audience-card">
+        <h3>Team leads</h3>
+        <p>Give production maps a safer release process with branches, review points, and rollback options.</p>
+      </div>
+      <div class="audience-card">
+        <h3>Enterprise ArcGIS shops</h3>
+        <p>Compare staging and production state, keep many repos synced, and make map releases less fragile.</p>
+      </div>
     </div>
-    <div class="feature-card">
-      <div class="feature-icon">🔀</div>
-      <div class="feature-title">Merge</div>
-      <div class="feature-desc">Bring branches back together. Conflict detection keeps your maps safe.</div>
+  </section>
+
+  <hr class="divider" />
+
+  <section id="install">
+    <div class="section-label">Install</div>
+    <h2>Up and running in a few minutes.</h2>
+    <p class="section-desc">Install from PyPI, set your ArcGIS credentials, then clone a map and inspect its history like you would a code repo.</p>
+
+    <div class="install-shell">
+      <div class="install-block">
+<div><span class="install-comment"># Install and confirm the CLI is available</span></div>
+<div><span class="install-cmd">pip install gitmap</span></div>
+<div><span class="install-cmd">gitmap --version</span></div>
+<br />
+<div><span class="install-comment"># Set ArcGIS Online or Portal credentials</span></div>
+<div><span class="install-cmd">export PORTAL_URL=https://your-org.maps.arcgis.com</span></div>
+<div><span class="install-cmd">export ARCGIS_USERNAME=your_username</span></div>
+<div><span class="install-cmd">export ARCGIS_PASSWORD=your_password</span></div>
+<br />
+<div><span class="install-comment"># Clone a map, branch, and review the diff</span></div>
+<div><span class="install-cmd">gitmap clone abc123def456</span></div>
+<div><span class="install-cmd">cd MyWebMap</span></div>
+<div><span class="install-cmd">gitmap branch feature/hydrology-update</span></div>
+<div><span class="install-cmd">gitmap diff main feature/hydrology-update</span></div>
+      </div>
+
+      <div class="install-side">
+        <div class="card">
+          <h3>What you need</h3>
+          <ul class="clean">
+            <li>Python 3.11, 3.12, 3.13, or 3.14</li>
+            <li>ArcGIS Online or Portal for ArcGIS access</li>
+            <li>A web map item ID to clone or a new map to initialize</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>Helpful next steps</h3>
+          <ul class="clean">
+            <li>Run <code>gitmap doctor</code> if auth fails</li>
+            <li>Open the full quickstart in the docs</li>
+            <li>Review workflow guides before using it on a production map</li>
+          </ul>
+        </div>
+        <div class="badges">
+          <img src="https://github.com/14-TR/Git-Map/actions/workflows/ci.yml/badge.svg" alt="CI status" />
+          <img src="https://img.shields.io/pypi/v/gitmap.svg" alt="PyPI version" />
+          <img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue" alt="Supported Python versions" />
+          <img src="https://img.shields.io/badge/tests-734%2B-brightgreen" alt="Test coverage count" />
+        </div>
+      </div>
     </div>
-    <div class="feature-card">
-      <div class="feature-icon">⏪</div>
-      <div class="feature-title">Revert &amp; Reset</div>
-      <div class="feature-desc">One command to undo any commit or restore a historical map state.</div>
+
+    <div class="hero-actions" style="margin-top: 1.5rem;">
+      <a class="btn-primary" href="https://14-tr.github.io/Git-Map/getting-started/quickstart/" target="_blank" rel="noreferrer">Open quickstart guide →</a>
+      <a class="btn-secondary" href="https://github.com/14-TR/Git-Map" target="_blank" rel="noreferrer">Browse source on GitHub</a>
     </div>
-    <div class="feature-card">
-      <div class="feature-icon">🔁</div>
-      <div class="feature-title">Push &amp; Pull</div>
-      <div class="feature-desc">Sync map state to/from ArcGIS Portal — share across teams and environments.</div>
+  </section>
+
+  <hr class="divider" />
+
+  <section id="faq">
+    <div class="section-label">FAQ</div>
+    <h2>Short answers to the first questions people usually ask.</h2>
+    <div class="faq-grid">
+      <div class="faq-item">
+        <h3>Does GitMap version the underlying feature data?</h3>
+        <p>No. GitMap versions the web map item JSON: layer references, symbology, popups, visibility, extent, and related configuration.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Does it work with ArcGIS Online and Enterprise?</h3>
+        <p>Yes. GitMap is built for ArcGIS Online and Portal for ArcGIS workflows.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Is this only for developers?</h3>
+        <p>It is a CLI-first tool today, so it fits best for technical GIS staff, GIS developers, and teams comfortable with lightweight scripting.</p>
+      </div>
+      <div class="faq-item">
+        <h3>Can I try it safely?</h3>
+        <p>Yes — start with a non-critical map, branch before making changes, and review the diff before merging or pushing.</p>
+      </div>
     </div>
-    <div class="feature-card">
-      <div class="feature-icon">⚙️</div>
-      <div class="feature-title">ArcGIS Pro Toolbox</div>
-      <div class="feature-desc">9 native geoprocessing tools so you can run GitMap workflows directly inside ArcGIS Pro.</div>
-    </div>
-    <div class="feature-card">
-      <div class="feature-icon">🤖</div>
-      <div class="feature-title">Auto-Pull</div>
-      <div class="feature-desc">Schedule automatic syncs to keep local repos in step with live Portal maps.</div>
+  </section>
+
+  <div class="cta">
+    <div class="cta-card">
+      <div class="cta-copy">
+        <h2>Give your maps a safer release workflow.</h2>
+        <p>Install GitMap, walk through the quickstart, and test it on a staging or non-critical web map first. If the workflow clicks, the same patterns scale to real production releases.</p>
+      </div>
+      <div class="hero-actions" style="margin-bottom: 0;">
+        <a class="btn-primary" href="#install">Start with pip install</a>
+        <a class="btn-secondary" href="https://14-tr.github.io/Git-Map/guides/workflow/" target="_blank" rel="noreferrer">See the workflow guide</a>
+      </div>
     </div>
   </div>
-</section>
 
-<hr class="divider"/>
-
-<!-- INSTALL SECTION -->
-<section id="install">
-  <div class="section-label">Get Started</div>
-  <h2>Up and running in 2 minutes.</h2>
-  <p class="section-desc">Requires Python 3.11+ and an ArcGIS Online or Portal account.</p>
-
-  <div class="badges">
-    <img src="https://github.com/14-TR/Git-Map/actions/workflows/ci.yml/badge.svg" alt="CI" />
-    <img src="https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue" alt="Python" />
-    <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT" />
-    <img src="https://img.shields.io/badge/tests-450%2B-brightgreen" alt="Tests" />
-  </div>
-
-  <div class="install-block">
-    <div><span class="install-comment"># Install from PyPI</span></div>
-    <div><span class="install-cmd">pip install gitmap</span></div>
-    <br/>
-    <div><span class="install-comment"># Initialize a repo for an existing web map</span></div>
-    <div><span class="install-cmd">gitmap init --portal https://org.maps.arcgis.com --item-id &lt;map-id&gt;</span></div>
-    <br/>
-    <div><span class="install-comment"># Commit the current state</span></div>
-    <div><span class="install-cmd">gitmap commit -m "Initial commit"</span></div>
-    <br/>
-    <div><span class="install-comment"># Create a branch and start experimenting</span></div>
-    <div><span class="install-cmd">gitmap branch feature/my-changes && gitmap checkout feature/my-changes</span></div>
-  </div>
-
-  <br/>
-  <div style="display:flex; gap:1rem; flex-wrap:wrap; margin-top:1.5rem;">
-    <a class="btn-primary" href="https://14-tr.github.io/Git-Map/getting-started/" target="_blank">Full Getting Started Guide →</a>
-    <a class="btn-secondary" href="https://github.com/14-TR/Git-Map" target="_blank">GitHub Repository</a>
-  </div>
-</section>
-
-<!-- FOOTER -->
-<footer>
-  <p>
-    GitMap is open source (MIT) · Built by <a href="https://ingramgeoai.com" target="_blank">TR Ingram</a> ·
-    <a href="https://github.com/14-TR/Git-Map" target="_blank">GitHub</a> ·
-    <a href="https://14-tr.github.io/Git-Map/" target="_blank">Documentation</a>
-  </p>
-</footer>
-
+  <footer>
+    <p>
+      GitMap is open source (MIT) · Built by <a href="https://ingramgeoai.com" target="_blank" rel="noreferrer">TR Ingram</a> ·
+      <a href="https://github.com/14-TR/Git-Map" target="_blank" rel="noreferrer">GitHub</a> ·
+      <a href="https://14-tr.github.io/Git-Map/" target="_blank" rel="noreferrer">Documentation</a>
+    </p>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Polish the static GitMap landing page for first-time GIS visitors
- Clarify ArcGIS web-map version-control value prop, workflow, audience, install path, and FAQ
- Add stronger quickstart/docs CTAs while keeping the slice to `landing/index.html`

## Verification
- `python3` HTMLParser smoke on `landing/index.html` ✅
- Manual content smoke: hero, workflow, install CTA, FAQ, and docs/GitHub links checked ✅
- `.venv/bin/python -m pytest tests/ -x -q` reports `ERROR: file or directory not found: tests/` because this repo has no top-level `tests/` directory
- `.venv/bin/python -m pytest -x -q` ✅ `776 passed in 2.48s`
- `git diff --check` and `git diff --cached --check` ✅
