### PR TITLE
feat: enable JSON diff output

### DIFF
--- a/apps/cli/gitmap/commands/diff.py
+++ b/apps/cli/gitmap/commands/diff.py
@@ -214,7 +214,9 @@ def _print_diff(
 # ---- Diff Command -------------------------------------------------------------------------------------------
 
 
-@click.command(epilog="Tip: use --format visual for a Rich table, or --format html to export a shareable report.")
+@click.command(
+    epilog="Tip: use --format visual for a Rich table, --format html to export a shareable report, or --format json for automation."
+)
 @click.argument(
     "source",
     required=False,
@@ -232,10 +234,10 @@ def _print_diff(
 @click.option(
     "--format",
     "fmt",
-    type=click.Choice(["text", "visual", "html"], case_sensitive=False),
+    type=click.Choice(["text", "visual", "html", "json"], case_sensitive=False),
     default="text",
     show_default=True,
-    help="Output format: 'text' for plain summary, 'visual' for Rich table, 'html' for exportable report.",
+    help="Output format: 'text' for plain summary, 'visual' for Rich table, 'html' for exportable report, 'json' for automation.",
 )
 @click.option(
     "--output",
@@ -264,6 +266,7 @@ def diff(
         gitmap diff abc123                        # Index vs commit abc123
         gitmap diff main feature/new-layer        # Branch vs branch
         gitmap diff main feature --format visual  # Visual table view
+        gitmap diff main feature --format json    # Machine-readable JSON
         gitmap diff abc123 def456                 # Commit vs commit
     """
     try:

--- a/packages/gitmap_core/tests/test_diff.py
+++ b/packages/gitmap_core/tests/test_diff.py
@@ -645,6 +645,44 @@ class TestResolveRef:
         result = _resolve_ref(repo, "nonexistent-branch")
         assert result is None
 
+    def test_diff_format_json_outputs_valid_mapdiff_json(self, tmp_path, monkeypatch) -> None:
+        """The CLI accepts --format json and emits the existing MapDiff.to_dict() shape."""
+        import json
+        import os
+        import sys
+
+        from click.testing import CliRunner
+        from gitmap_core.repository import init_repository
+
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "apps", "cli"))
+        from gitmap.commands.diff import diff
+
+        repo = init_repository(tmp_path, user_name="tester", user_email="t@t.com")
+        repo.update_index({"operationalLayers": [{"id": "l1", "title": "Base Layer"}], "tables": []})
+        repo.create_commit(message="base")
+        repo.update_index(
+            {
+                "operationalLayers": [
+                    {"id": "l1", "title": "Base Layer"},
+                    {"id": "l2", "title": "Added Layer"},
+                ],
+                "tables": [],
+            }
+        )
+
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(diff, ["--format", "json"])
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert set(payload) == {"has_changes", "stats", "layer_changes", "table_changes", "property_changes"}
+        assert payload["has_changes"] is True
+        assert payload["stats"]["added"] == 1
+        assert payload["table_changes"] == []
+        assert payload["property_changes"] == {}
+        assert payload["layer_changes"][0]["layer_id"] == "l2"
+        assert payload["layer_changes"][0]["change_type"] == "added"
+
 
 class TestBranchToBranchDiff:
     """Integration tests for branch-to-branch diff via diff_maps."""


### PR DESCRIPTION
## Problem
`gitmap diff --format json` had an existing renderer path in `_print_diff()`, but the Click option rejected `json`, blocking automation and future diff visualization consumers from using `MapDiff.to_dict()` output.

## Scope
- Add `json` to the accepted `gitmap diff --format` choices.
- Update the diff command help/example text to mention JSON automation output.
- Add a focused CLI smoke regression proving JSON output exits successfully and preserves the existing `MapDiff.to_dict()` top-level shape.

## Non-scope
- No diff engine rewrite.
- No UI/browser/HTML behavior changes beyond existing help text.
- No repository storage, branch resolution, merge, release, or versioning changes.

## Files changed
- `apps/cli/gitmap/commands/diff.py`
- `packages/gitmap_core/tests/test_diff.py`

## Verification
- Synthetic CLI smoke: exit `0`; JSON keys `['has_changes', 'layer_changes', 'property_changes', 'stats', 'table_changes']`; `has_changes=True`, `stats.added=1`, first layer `l2`.
- `python -m pytest packages/gitmap_core/tests/test_diff.py -q` → `77 passed`.
- `python -m pytest tests/ -x -q` → blocked because `tests/` does not exist in this repo/worktree.
- `python -m pytest packages/gitmap_core/tests -x -q` → `777 passed`.

## Known limitations
- JSON output intentionally serializes the existing `MapDiff.to_dict()` shape only; no new schema/version field is introduced in this slice.
- `--output` remains HTML-only behavior as before; JSON is emitted to stdout.

## Rollback risk
Low. Reverting this commit restores the previous Click format contract while leaving existing text, visual, and HTML paths unchanged.
