### PR TITLE
feat: stabilize JSON diff schema

### DIFF
--- a/docs/commands/diff.md
+++ b/docs/commands/diff.md
@@ -20,7 +20,7 @@ gitmap diff [SOURCE] [TARGET] [OPTIONS]
 | Option | Short | Default | Description |
 |--------|-------|---------|-------------|
 | `--verbose` | `-v` | false | Show property-level field changes |
-| `--format` | | `text` | Output format: `text`, `visual`, or `html` |
+| `--format` | | `text` | Output format: `text`, `visual`, `html`, or `json` |
 | `--output` | `-o` | `diff-report.html` | Output file path (used with `--format html`) |
 
 ## Modes
@@ -52,6 +52,9 @@ gitmap diff main feature/new-basemap --format visual
 # Export shareable HTML report
 gitmap diff main feature --format html
 gitmap diff main feature --format html --output /tmp/my-diff.html
+
+# Emit machine-readable JSON for automation
+gitmap diff main feature --format json
 
 # Show field-level changes
 gitmap diff --verbose
@@ -93,6 +96,34 @@ Renders a Rich table with colored diff symbols:
      Layer / Table           Change
   +  Flood Zones             added
   ~  Parcels                 2 field(s) changed
+```
+
+## JSON output (`--format json`)
+
+Emits a stable `gitmap.diff.v1` JSON payload for automation:
+
+```json
+{
+  "schema": "gitmap.diff.v1",
+  "has_changes": true,
+  "stats": {"added": 1, "removed": 0, "modified": 0, "total": 1},
+  "layer_changes": [
+    {
+      "object_type": "layer",
+      "layer_id": "flood-zones",
+      "title": "Flood Zones",
+      "change_type": "added"
+    }
+  ],
+  "table_changes": [],
+  "property_changes": {}
+}
+```
+
+Layer and table changes use the same object shape. `object_type` is `layer` or `table`, and `details` appears only when field-level details are available for a modified object.
+
+```bash
+gitmap diff main staging --format json
 ```
 
 ## HTML output (`--format html`)

--- a/packages/gitmap_core/diff.py
+++ b/packages/gitmap_core/diff.py
@@ -113,8 +113,9 @@ class MapDiff:
             and summary statistics.
         """
 
-        def _change_to_dict(c: LayerChange) -> dict[str, Any]:
+        def _change_to_dict(c: LayerChange, object_type: str) -> dict[str, Any]:
             d: dict[str, Any] = {
+                "object_type": object_type,
                 "layer_id": c.layer_id,
                 "title": c.layer_title,
                 "change_type": c.change_type,
@@ -124,10 +125,11 @@ class MapDiff:
             return d
 
         return {
+            "schema": "gitmap.diff.v1",
             "has_changes": self.has_changes,
             "stats": format_diff_stats(self),
-            "layer_changes": [_change_to_dict(c) for c in self.layer_changes],
-            "table_changes": [_change_to_dict(c) for c in self.table_changes],
+            "layer_changes": [_change_to_dict(c, "layer") for c in self.layer_changes],
+            "table_changes": [_change_to_dict(c, "table") for c in self.table_changes],
             "property_changes": self.property_changes,
         }
 

--- a/packages/gitmap_core/tests/test_diff.py
+++ b/packages/gitmap_core/tests/test_diff.py
@@ -675,11 +675,20 @@ class TestResolveRef:
 
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
-        assert set(payload) == {"has_changes", "stats", "layer_changes", "table_changes", "property_changes"}
+        assert set(payload) == {
+            "schema",
+            "has_changes",
+            "stats",
+            "layer_changes",
+            "table_changes",
+            "property_changes",
+        }
+        assert payload["schema"] == "gitmap.diff.v1"
         assert payload["has_changes"] is True
         assert payload["stats"]["added"] == 1
         assert payload["table_changes"] == []
         assert payload["property_changes"] == {}
+        assert payload["layer_changes"][0]["object_type"] == "layer"
         assert payload["layer_changes"][0]["layer_id"] == "l2"
         assert payload["layer_changes"][0]["change_type"] == "added"
 
@@ -1109,6 +1118,7 @@ class TestMapDiffToDict:
         """Empty diff serializes correctly."""
         map_diff = MapDiff()
         result = map_diff.to_dict()
+        assert result["schema"] == "gitmap.diff.v1"
         assert result["has_changes"] is False
         assert result["stats"]["total"] == 0
         assert result["layer_changes"] == []
@@ -1131,6 +1141,7 @@ class TestMapDiffToDict:
         assert result["stats"]["added"] == 1
         assert len(result["layer_changes"]) == 1
         change = result["layer_changes"][0]
+        assert change["object_type"] == "layer"
         assert change["layer_id"] == "l1"
         assert change["title"] == "Roads"
         assert change["change_type"] == "added"
@@ -1174,6 +1185,7 @@ class TestMapDiffToDict:
         assert result["stats"]["modified"] == 2  # 1 layer + property_changes
         assert len(result["layer_changes"]) == 3
         assert len(result["table_changes"]) == 1
+        assert result["table_changes"][0]["object_type"] == "table"
         assert result["property_changes"] == {"baseMap": "changed"}
 
     def test_to_dict_is_json_serializable(self) -> None:


### PR DESCRIPTION
## Summary
- add a stable `gitmap.diff.v1` schema marker to JSON diff output
- include `object_type` on layer/table JSON change records so automation consumers can distinguish record types without relying on array names
- document the JSON contract and cover the new fields in diff tests

## Tests
- `python -m pytest packages/gitmap_core/tests/test_diff.py -q`
- `python -m pytest packages/gitmap_core/tests -x -q`
- `git diff --check`

## Security review
- Current open PR body/diff scan: no IPs, Tailscale names, tokens, private endpoints, or local filesystem paths found
- New branch diff scan: no IPs, Tailscale names, tokens, private endpoints, or sensitive local paths found
- Local checkout remote URL was changed from an embedded-token URL to a clean GitHub URL before push
