### PR TITLE
feat: show changed field paths in diffs

### DIFF
--- a/docs/commands/diff.md
+++ b/docs/commands/diff.md
@@ -95,7 +95,7 @@ Renders a Rich table with colored diff symbols:
 
      Layer / Table           Change
   +  Flood Zones             added
-  ~  Parcels                 2 field(s) changed
+  ~  Parcels                 2 fields changed: opacity, popupInfo.title
 ```
 
 ## JSON output (`--format json`)
@@ -131,7 +131,8 @@ gitmap diff main staging --format json
 Self-contained dark-themed HTML report with:
 - Stats badges (added / removed / modified counts)
 - Color-coded diff table
-- Expanded JSON detail block for modified layers
+- Concise changed-field paths in modified rows
+- Expanded JSON detail blocks for modified layers, tables, and map properties
 - Footer with generation timestamp
 
 Useful for sharing diffs with stakeholders who don't have GitMap installed.

--- a/docs/guides/reviewing-diffs.md
+++ b/docs/guides/reviewing-diffs.md
@@ -46,6 +46,7 @@ Look for these signals:
 - `*` Top-level map property changed
 
 This is the best default for branch-to-branch reviews because it shows **what changed** without overwhelming you with every nested field.
+For modified rows, the detail column includes the first changed property paths, such as `opacity` or `drawingInfo.renderer.type`, so reviewers can quickly tell whether a change is a visual style edit, popup edit, visibility change, or broader map setting change.
 
 ## Detailed investigation: `--verbose`
 
@@ -66,7 +67,7 @@ Tip: start with `--format visual`, then re-run with `--verbose` only when someth
 
 ## Sharing with non-technical reviewers: HTML reports
 
-The HTML formatter creates a self-contained report with badges, a color-coded change table, and detailed JSON blocks for modified layers.
+The HTML formatter creates a self-contained report with badges, a color-coded change table, changed-field summaries, and detailed JSON blocks for modified layers, tables, and map-level properties.
 
 ```bash
 gitmap diff main release/q2-map-update --format html --output reports/q2-map-update.html

--- a/packages/gitmap_core/diff.py
+++ b/packages/gitmap_core/diff.py
@@ -16,6 +16,7 @@ Metadata:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -260,6 +261,86 @@ def diff_json(
 # ---- Formatting Functions -----------------------------------------------------------------------------------
 
 
+_PATH_RE = re.compile(r"\['([^']+)'\]|\[(\d+)\]")
+
+
+def _format_deepdiff_path(path: Any) -> str:
+    """Convert a DeepDiff path into a compact, reviewer-friendly field path."""
+    if not isinstance(path, str):
+        return str(path)
+
+    if not path.startswith("root"):
+        return path
+
+    parts: list[str] = []
+    for key, index in _PATH_RE.findall(path):
+        if key:
+            parts.append(key)
+        elif index and parts:
+            parts[-1] = f"{parts[-1]}[{index}]"
+        elif index:
+            parts.append(f"[{index}]")
+    return ".".join(parts) if parts else "root"
+
+
+def _iter_deepdiff_paths(details: dict[str, Any]) -> list[str]:
+    """Return stable field paths from a DeepDiff ``to_dict`` payload."""
+    paths: list[str] = []
+    seen: set[str] = set()
+    categories = (
+        "values_changed",
+        "type_changes",
+        "dictionary_item_added",
+        "dictionary_item_removed",
+        "iterable_item_added",
+        "iterable_item_removed",
+    )
+
+    for category in (*categories, *(key for key in details if key not in categories)):
+        changes = details.get(category)
+        if isinstance(changes, dict):
+            raw_paths = changes.keys()
+        elif isinstance(changes, (list, set, tuple)):
+            raw_paths = changes
+        else:
+            raw_paths = []
+
+        for raw_path in raw_paths:
+            path = _format_deepdiff_path(raw_path)
+            if path not in seen:
+                seen.add(path)
+                paths.append(path)
+
+    return paths
+
+
+def format_diff_detail(
+    details: dict[str, Any],
+    max_paths: int = 3,
+) -> str:
+    """Format DeepDiff details as a compact changed-field summary."""
+    if not details:
+        return "1 field changed"
+
+    paths = _iter_deepdiff_paths(details)
+    count = len(paths) or len(details)
+    noun = "field" if count == 1 else "fields"
+
+    if not paths:
+        return f"{count} {noun} changed"
+
+    shown = paths[:max_paths]
+    suffix = f", +{len(paths) - max_paths} more" if len(paths) > max_paths else ""
+    return f"{count} {noun} changed: {', '.join(shown)}{suffix}"
+
+
+def _json_default(value: Any) -> Any:
+    """Make DeepDiff set-like categories printable in JSON detail blocks."""
+    if isinstance(value, set):
+        return sorted(value, key=str)
+    return str(value)
+
+
 def format_diff_summary(
     map_diff: MapDiff,
 ) -> str:
@@ -289,7 +370,7 @@ def format_diff_summary(
     if map_diff.modified_layers:
         lines.append(f"Modified layers ({len(map_diff.modified_layers)}):")
         for change in map_diff.modified_layers:
-            lines.append(f"  ~ {change.layer_title} ({change.layer_id})")
+            lines.append(f"  ~ {change.layer_title} ({change.layer_id}) - {format_diff_detail(change.details)}")
 
     if map_diff.added_tables:
         lines.append(f"Added tables ({len(map_diff.added_tables)}):")
@@ -304,12 +385,10 @@ def format_diff_summary(
     if map_diff.modified_tables:
         lines.append(f"Modified tables ({len(map_diff.modified_tables)}):")
         for change in map_diff.modified_tables:
-            lines.append(f"  ~ {change.layer_title} ({change.layer_id})")
+            lines.append(f"  ~ {change.layer_title} ({change.layer_id}) - {format_diff_detail(change.details)}")
 
     if map_diff.property_changes:
-        lines.append("Map properties changed:")
-        for key in map_diff.property_changes:
-            lines.append(f"  * {key}")
+        lines.append(f"Map properties changed: {format_diff_detail(map_diff.property_changes)}")
 
     return "\n".join(lines)
 
@@ -342,9 +421,7 @@ def format_diff_visual(
         rows.append(("-", change.layer_title, f"Removed in {label_a} (present in {label_b})"))
 
     for change in map_diff.modified_layers:
-        num_changes = len(change.details) if change.details else 1
-        detail = f"{num_changes} field(s) changed"
-        rows.append(("~", change.layer_title, detail))
+        rows.append(("~", change.layer_title, format_diff_detail(change.details)))
 
     for change in map_diff.added_tables:
         rows.append(("+", f"[table] {change.layer_title}", f"Added in {label_a}"))
@@ -353,11 +430,10 @@ def format_diff_visual(
         rows.append(("-", f"[table] {change.layer_title}", f"Removed in {label_a} (present in {label_b})"))
 
     for change in map_diff.modified_tables:
-        num_changes = len(change.details) if change.details else 1
-        rows.append(("~", f"[table] {change.layer_title}", f"{num_changes} field(s) changed"))
+        rows.append(("~", f"[table] {change.layer_title}", format_diff_detail(change.details)))
 
     if map_diff.property_changes:
-        rows.append(("*", "Map properties", f"{len(map_diff.property_changes)} top-level field(s) changed"))
+        rows.append(("*", "Map properties", format_diff_detail(map_diff.property_changes)))
 
     return rows
 
@@ -385,7 +461,7 @@ def format_diff_stats(map_diff: MapDiff) -> dict[str, int]:
 
 
 def format_diff_html(
-    map_diff: "MapDiff",
+    map_diff: MapDiff,
     label_a: str = "source",
     label_b: str = "target",
     title: str = "GitMap Diff Report",
@@ -406,11 +482,11 @@ def format_diff_html(
     """
     import html
     import json
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     stats = format_diff_stats(map_diff)
     rows = format_diff_visual(map_diff, label_a, label_b)
-    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
 
     # Build stats badges
     badge_parts: list[str] = []
@@ -445,16 +521,28 @@ def format_diff_html(
 
     # Build detailed changes section
     detail_sections: list[str] = []
-    for change in map_diff.modified_layers:
-        if change.details:
-            details_str = html.escape(json.dumps(change.details, indent=2))
-            detail_sections.append(
-                f'<div class="detail-block">'
-                f"<h3>Layer: {html.escape(change.layer_title)}"
-                f' <code class="layer-id">{html.escape(change.layer_id)}</code></h3>'
-                f'<pre class="json-block">{details_str}</pre>'
-                f"</div>"
-            )
+    for label, changes in (("Layer", map_diff.modified_layers), ("Table", map_diff.modified_tables)):
+        for change in changes:
+            if change.details:
+                details_str = html.escape(json.dumps(change.details, indent=2, default=_json_default))
+                detail_sections.append(
+                    f'<div class="detail-block">'
+                    f"<h3>{label}: {html.escape(change.layer_title)}"
+                    f' <code class="layer-id">{html.escape(change.layer_id)}</code></h3>'
+                    f'<p class="detail-summary">{html.escape(format_diff_detail(change.details, max_paths=5))}</p>'
+                    f'<pre class="json-block">{details_str}</pre>'
+                    f"</div>"
+                )
+
+    if map_diff.property_changes:
+        property_details_str = html.escape(json.dumps(map_diff.property_changes, indent=2, default=_json_default))
+        detail_sections.append(
+            f'<div class="detail-block">'
+            f"<h3>Map Properties</h3>"
+            f'<p class="detail-summary">{html.escape(format_diff_detail(map_diff.property_changes, max_paths=5))}</p>'
+            f'<pre class="json-block">{property_details_str}</pre>'
+            f"</div>"
+        )
 
     details_html = ""
     if detail_sections:
@@ -519,6 +607,7 @@ def format_diff_html(
                      margin-bottom: 1rem; overflow: hidden; }}
     .detail-block h3 {{ padding: 0.75rem 1rem; font-size: 0.95rem;
                          border-bottom: 1px solid var(--border); }}
+    .detail-summary {{ padding: 0.75rem 1rem 0; color: var(--muted); font-size: 0.85rem; }}
     code.layer-id {{ font-family: var(--font-mono); font-size: 0.8rem;
                       color: var(--muted); margin-left: 0.5rem; }}
     pre.json-block {{ font-family: var(--font-mono); font-size: 0.78rem; color: #a5f3fc;

--- a/packages/gitmap_core/tests/test_diff.py
+++ b/packages/gitmap_core/tests/test_diff.py
@@ -12,9 +12,9 @@ Dependencies:
 
 from __future__ import annotations
 
-import pytest
+from typing import TYPE_CHECKING
 
-from pathlib import Path
+import pytest
 
 from gitmap_core.diff import (
     LayerChange,
@@ -22,9 +22,14 @@ from gitmap_core.diff import (
     diff_json,
     diff_layers,
     diff_maps,
+    format_diff_detail,
     format_diff_summary,
 )
-from gitmap_core.repository import Repository
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from gitmap_core.repository import Repository
 
 try:
     import click  # noqa: F401
@@ -524,14 +529,19 @@ class TestFormatDiffSummary:
         """Test formatting modified layers."""
         diff = MapDiff(
             layer_changes=[
-                LayerChange("l1", "Updated Layer", "modified"),
+                LayerChange(
+                    "l1",
+                    "Updated Layer",
+                    "modified",
+                    details={"values_changed": {"root['opacity']": {"old_value": 1.0, "new_value": 0.5}}},
+                ),
             ]
         )
 
         result = format_diff_summary(diff)
 
         assert "Modified layers (1):" in result
-        assert "~ Updated Layer (l1)" in result
+        assert "~ Updated Layer (l1) - 1 field changed: opacity" in result
 
     def test_format_table_changes(self) -> None:
         """Test formatting table changes."""
@@ -560,9 +570,53 @@ class TestFormatDiffSummary:
 
         result = format_diff_summary(diff)
 
-        assert "Map properties changed:" in result
-        assert "* values_changed" in result
-        assert "* dictionary_item_added" in result
+        assert "Map properties changed: 2 fields changed" in result
+        assert "version" in result
+        assert "newKey" in result
+
+
+class TestFormatDiffDetail:
+    """Tests for compact DeepDiff detail summaries."""
+
+    def test_formats_nested_paths(self) -> None:
+        """DeepDiff paths are converted into readable dotted paths."""
+        details = {
+            "values_changed": {
+                "root['drawingInfo']['renderer']['type']": {"old_value": "simple", "new_value": "uniqueValue"},
+                "root['opacity']": {"old_value": 1.0, "new_value": 0.4},
+            }
+        }
+
+        result = format_diff_detail(details)
+
+        assert result == "2 fields changed: drawingInfo.renderer.type, opacity"
+
+    def test_limits_long_path_lists(self) -> None:
+        """Long summaries show the first paths and a remaining count."""
+        details = {
+            "values_changed": {
+                "root['a']": {},
+                "root['b']": {},
+                "root['c']": {},
+                "root['d']": {},
+            }
+        }
+
+        result = format_diff_detail(details, max_paths=2)
+
+        assert result == "4 fields changed: a, b, +2 more"
+
+    def test_handles_added_and_removed_paths(self) -> None:
+        """Path extraction includes dictionary additions and removals."""
+        details = {
+            "dictionary_item_added": {"root['popupInfo']"},
+            "dictionary_item_removed": {"root['labelingInfo']"},
+        }
+
+        result = format_diff_detail(details)
+
+        assert "popupInfo" in result
+        assert "labelingInfo" in result
 
     def test_format_mixed_changes(self) -> None:
         """Test formatting multiple types of changes."""
@@ -652,6 +706,7 @@ class TestResolveRef:
         import sys
 
         from click.testing import CliRunner
+
         from gitmap_core.repository import init_repository
 
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "apps", "cli"))
@@ -853,7 +908,30 @@ class TestFormatDiffVisual:
         symbol, name, detail = rows[0]
         assert symbol == "~"
         assert name == "Buildings"
-        assert "1" in detail
+        assert detail == "1 field changed: opacity"
+
+    def test_modified_layer_row_shows_nested_paths(self) -> None:
+        """Modified rows include enough field context to support review."""
+        from gitmap_core.diff import format_diff_visual
+
+        map_diff = MapDiff(
+            layer_changes=[
+                LayerChange(
+                    layer_id="l3",
+                    layer_title="Buildings",
+                    change_type="modified",
+                    details={
+                        "values_changed": {
+                            "root['drawingInfo']['renderer']['type']": {},
+                            "root['popupInfo']['title']": {},
+                        }
+                    },
+                )
+            ]
+        )
+        rows = format_diff_visual(map_diff)
+
+        assert rows[0][2] == "2 fields changed: drawingInfo.renderer.type, popupInfo.title"
 
     def test_property_changes_row(self) -> None:
         """Map-level property changes produce a '*' row."""
@@ -1048,6 +1126,7 @@ class TestFormatDiffHtml:
         )
         result = format_diff_html(map_diff, "index", "HEAD")
         assert "Detailed Field Changes" in result
+        assert "1 field changed: opacity" in result
         assert "values_changed" in result
 
     def test_no_detail_section_when_no_details(self) -> None:
@@ -1078,9 +1157,30 @@ class TestFormatDiffHtml:
         """Map property changes are included in the output."""
         from gitmap_core.diff import format_diff_html
 
-        map_diff = MapDiff(property_changes={"values_changed": {}})
+        map_diff = MapDiff(property_changes={"values_changed": {"root['baseMap']['title']": {}}})
         result = format_diff_html(map_diff, "main", "feature")
         assert "Map properties" in result
+        assert "Map Properties" in result
+        assert "baseMap.title" in result
+
+    def test_table_details_appear_in_output(self) -> None:
+        """Modified table details are rendered in the detailed section."""
+        from gitmap_core.diff import format_diff_html
+
+        map_diff = MapDiff(
+            table_changes=[
+                LayerChange(
+                    layer_id="t1",
+                    layer_title="Lookup Table",
+                    change_type="modified",
+                    details={"dictionary_item_added": {"root['fields'][0]"}},
+                ),
+            ]
+        )
+        result = format_diff_html(map_diff, "main", "feature")
+
+        assert "Table: Lookup Table" in result
+        assert "fields[0]" in result
 
     def test_html_escaping(self) -> None:
         """Layer titles with HTML special chars are escaped."""


### PR DESCRIPTION
## Summary
- Add readable changed-field path summaries for modified layers, tables, and map properties
- Include field summaries in visual/text diff output and HTML reports
- Expand HTML detail blocks to cover modified tables and map-level properties, not only layers
- Document the improved visual and HTML review behavior

## Validation
- `ruff check packages/gitmap_core/diff.py packages/gitmap_core/tests/test_diff.py`
- `git diff --check`
- `PYTHONPATH=... python -m pytest packages/gitmap_core/tests/test_diff.py -q` → 82 passed
- `PYTHONPATH=... python -m pytest packages/gitmap_core/tests -q` → 782 passed

## Security / exposure check
- Scanned changed files for tokens, secrets, API keys, private hostnames, Tailscale references, local paths, loopback hosts, and private IP patterns.
- No sensitive exposure found in this diff.
