### PR TITLE
docs: correct PyPI install path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,14 +3,12 @@ name: Publish to PyPI
 # Tag conventions:
 #   core-v*   → publishes gitmap-core   (e.g. core-v0.6.1)
 #   cli-v*    → publishes gitmap-cli    (e.g. cli-v0.6.1)
-#   v*        → publishes gitmap meta   (e.g. v0.6.1)
 
 on:
   push:
     tags:
       - "core-v*"
       - "cli-v*"
-      - "v*"
 
 permissions:
   contents: read
@@ -122,61 +120,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: dist-cli
-          path: dist/
-
-      - name: Publish to PyPI (trusted publisher)
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-# ---------------------------------------------------------------------------
-# gitmap (meta-package)
-# ---------------------------------------------------------------------------
-  build-meta:
-    name: Build gitmap meta-package
-    if: "startsWith(github.ref_name, 'v') && !startsWith(github.ref_name, 'core-v') && !startsWith(github.ref_name, 'cli-v')"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install build tools
-        run: python -m pip install --upgrade pip build
-
-      - name: Validate release tag
-        run: python scripts/release_checks.py --ref-name "${{ github.ref_name }}"
-
-      - name: Run core tests before publishing
-        run: |
-          pip install -e "packages/gitmap_core[dev]"
-          python -m pytest packages/gitmap_core/tests -x -q
-
-      - name: Build gitmap wheel and sdist
-        run: python -m build . --outdir dist/
-
-      - name: Smoke-test gitmap meta-package dist install
-        run: python scripts/verify_dist_install.py meta
-
-      - name: Upload dist artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist-meta
-          path: dist/
-
-  publish-meta:
-    name: Publish gitmap meta-package to PyPI
-    needs: build-meta
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/gitmap
-    steps:
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist-meta
           path: dist/
 
       - name: Publish to PyPI (trusted publisher)

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,15 +2,14 @@
 
 GitMap uses **PyPI Trusted Publishing** (OIDC) — no API tokens needed once configured.
 
-GitMap ships three packages:
+GitMap currently publishes two user-facing packages. The root `gitmap` PyPI name is occupied by an unrelated project, so it is not part of the active publish contract unless that name is transferred or explicitly re-approved.
 
 | PyPI Package | Tag Pattern | Install |
 |---|---|---|
 | `gitmap-core` | `core-v*` | `pip install gitmap-core` |
 | `gitmap-cli` | `cli-v*` | `pip install gitmap-cli` |
-| `gitmap` (meta) | `v*` | `pip install gitmap` |
 
-> **Most users want `pip install gitmap`** — it installs both core and CLI automatically.
+> **Most users want `pip install gitmap-cli`** — it installs the `gitmap` console command and depends on `gitmap-core`. Use `pip install gitmap-core` only for library/API use.
 
 ---
 
@@ -29,14 +28,12 @@ twine upload dist/gitmap_core-*
 python -m build apps/cli/gitmap --outdir dist/
 twine upload dist/gitmap_cli-*
 
-# Meta-package
-python -m build . --outdir dist/
-twine upload dist/gitmap-*
+# Do not build/upload the root gitmap meta-package while the PyPI name is unavailable.
 ```
 
 ### 2. Configure Trusted Publishers on PyPI
 
-Do this for **each** of the three packages after they exist on PyPI:
+Do this for **each** active package after it exists on PyPI:
 
 1. Go to `https://pypi.org/manage/project/<package-name>/settings/`
 2. Click **"Add a new publisher"** under "Trusted Publishers"
@@ -49,7 +46,6 @@ Do this for **each** of the three packages after they exist on PyPI:
 Packages to configure:
 - `https://pypi.org/manage/project/gitmap-core/settings/`
 - `https://pypi.org/manage/project/gitmap-cli/settings/`
-- `https://pypi.org/manage/project/gitmap/settings/`
 
 ### 3. Create the GitHub `pypi` Environment
 
@@ -67,14 +63,12 @@ Before tagging, run the local release guardrails:
 python3 scripts/release_checks.py
 python3 -m build packages/gitmap_core --outdir dist/
 python3 -m build apps/cli/gitmap --outdir dist/
-python3 -m build . --outdir dist/
 python3 scripts/verify_dist_install.py core
 python3 scripts/verify_dist_install.py cli
-python3 scripts/verify_dist_install.py meta
 ```
 
-This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned. It also catches root meta-package build regressions, which is important in this monorepo because setuptools can otherwise try to auto-discover top-level folders instead of building the `gitmap` meta-package.
-The publish workflow now runs the same clean-venv install smoke test for `core`, `cli`, and `meta` before uploading artifacts to PyPI.
+This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned.
+The publish workflow now runs the same clean-venv install smoke test for `core` and `cli` before uploading artifacts to PyPI.
 
 ### Patch release (core fix)
 
@@ -96,21 +90,19 @@ git tag cli-v0.6.1
 git push origin main --tags
 ```
 
-### Full release (all packages)
+### Full release (core + CLI)
 
 ```bash
-# 1. Bump versions in all three pyproject.toml files + main.py
+# 1. Bump versions in the core/CLI pyproject.toml files + main.py
 # 2. Commit
 git add packages/gitmap_core/pyproject.toml \
         apps/cli/gitmap/pyproject.toml \
-        apps/cli/gitmap/main.py \
-        pyproject.toml
+        apps/cli/gitmap/main.py
 git commit -m "chore: release v0.7.0"
 
-# 3. Tag all three — publish.yml fires for each
+# 3. Tag both active packages — publish.yml fires for each
 git tag core-v0.7.0
 git tag cli-v0.7.0
-git tag v0.7.0
 git push origin main --tags
 ```
 
@@ -118,13 +110,12 @@ git push origin main --tags
 
 ## Versioning Convention
 
-All three packages should stay in sync (same version number).
+The active publishable packages should stay in sync (same version number).
 
 | Component | File to update |
 |---|---|
 | `gitmap-core` | `packages/gitmap_core/pyproject.toml` |
 | `gitmap-cli` | `apps/cli/gitmap/pyproject.toml` + `apps/cli/gitmap/main.py` |
-| `gitmap` meta | `pyproject.toml` (root) |
 
 ---
 
@@ -133,8 +124,7 @@ All three packages should stay in sync (same version number).
 After tags are pushed and workflow runs succeed:
 
 ```bash
-pip install gitmap           # meta-package (installs core + cli)
+pip install gitmap-cli       # CLI (installs the gitmap command and core dependency)
 pip install gitmap-core      # core library only
-pip install gitmap-cli       # CLI only (also installs core)
 gitmap --version             # should show new version
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Version control for ArcGIS web maps.**
 
 [![CI](https://github.com/14-TR/Git-Map/actions/workflows/ci.yml/badge.svg)](https://github.com/14-TR/Git-Map/actions/workflows/ci.yml)
-[![PyPI](https://img.shields.io/pypi/v/gitmap.svg)](https://pypi.org/project/gitmap/)
+[![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Tests](https://img.shields.io/badge/tests-734%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
@@ -67,10 +67,10 @@ GitMap adds version-control primitives GIS teams already understand:
 ### Recommended: install from PyPI
 
 ```bash
-pip install gitmap
+pip install gitmap-cli
 ```
 
-Verify the CLI is available:
+This installs the `gitmap` console command. Verify the CLI is available:
 
 ```bash
 gitmap --version

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,10 +8,10 @@
 ## Install from PyPI
 
 ```bash
-pip install gitmap
+pip install gitmap-cli
 ```
 
-This installs both the core library and the `gitmap` CLI command in one step.
+This installs both the core library dependency and the `gitmap` CLI command in one step.
 
 Verify the install:
 
@@ -21,7 +21,7 @@ gitmap --version
 
 !!! tip "Individual packages"
     If you only need the library (no CLI), install `gitmap-core` directly.
-    The `gitmap` meta-package is the recommended install for most users.
+    The `gitmap` PyPI name is not the default install path. Install `gitmap-core` only for library/API use.
 
 ## Install from Source
 
@@ -55,7 +55,7 @@ You can also store credentials in the repository config file — see [Working wi
 ## Upgrading
 
 ```bash
-pip install --upgrade gitmap
+pip install --upgrade gitmap-cli
 ```
 
 ---

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -7,7 +7,7 @@ Get from zero to your first committed map version in under 5 minutes.
 Make sure you have gitmap installed:
 
 ```bash
-pip install gitmap
+pip install gitmap-cli
 gitmap --version
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,10 +19,10 @@ Git-Map brings familiar Git-style workflows to ArcGIS Online and Portal for ArcG
 ## Quick Install
 
 ```bash
-pip install gitmap
+pip install gitmap-cli
 ```
 
-Then see the [Quickstart](getting-started/quickstart.md) to run your first commit in under 5 minutes.
+This installs the `gitmap` console command. Then see the [Quickstart](getting-started/quickstart.md) to run your first commit in under 5 minutes.
 
 ## Core Workflow
 

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -152,11 +152,13 @@ def validate_release_state() -> None:
         _validate_package_metadata(pyproject)
 
     workflow_text = PUBLISH_WORKFLOW.read_text()
-    for tag_pattern in ('- "core-v*"', '- "cli-v*"', '- "v*"'):
+    for tag_pattern in ('- "core-v*"', '- "cli-v*"'):
         assert tag_pattern in workflow_text, f"Missing publish tag pattern: {tag_pattern}"
-    for package_name in ("gitmap-core", "gitmap-cli", "gitmap"):
+    assert '- "v*"' not in workflow_text, "Root gitmap meta-package tags are not part of the active PyPI publish plan"
+    for package_name in ("gitmap-core", "gitmap-cli"):
         assert f"https://pypi.org/p/{package_name}" in workflow_text, f"Missing PyPI environment URL for {package_name}"
-    for dist_kind in ("core", "cli", "meta"):
+    assert "url: https://pypi.org/p/gitmap\n" not in workflow_text, "Root gitmap PyPI project is unavailable and must not be published"
+    for dist_kind in ("core", "cli"):
         assert f"python scripts/verify_dist_install.py {dist_kind}" in workflow_text, (
             f"Missing dist smoke-test step for {dist_kind}"
         )


### PR DESCRIPTION
## Problem statement

Public install docs and release guardrails still treated `pip install gitmap` as the default path, but the `gitmap` PyPI name is occupied by an unrelated project. That could send users to the wrong package.

## Scope

- Make `pip install gitmap-cli` the documented default user install.
- Clarify that `gitmap-cli` installs the `gitmap` console command.
- Keep `gitmap-core` documented for library/API-only users.
- Remove the active root `gitmap` meta-package publish path from the PyPI workflow while the name is unavailable.
- Narrow release guardrails to require active `gitmap-core` and `gitmap-cli` publish destinations.

## Non-scope

- No PyPI publishing.
- No tags or credentials.
- No package layout redesign.
- No rename of the `gitmap` console command or import packages.
- No work on excluded repos/projects.

## Files changed

- `README.md`
- `docs/index.md`
- `docs/getting-started/installation.md`
- `docs/getting-started/quickstart.md`
- `PUBLISHING.md`
- `scripts/release_checks.py`
- `.github/workflows/publish.yml`

## Verification

- `grep -R "pip install gitmap$\|pip install gitmap " -n README.md docs PUBLISHING.md` — no matches.
- `python3 scripts/release_checks.py` — passed (`Release metadata OK for GitMap v0.7.0`).
- `mkdocs build --strict` — passed.
- Full repo gate: repository has no top-level `tests/`, so ran `python3 -m pytest packages/gitmap_core/tests -x -q` from a Python 3.14 virtualenv because host `/usr/bin/python3` is Python 3.9.6 and the package requires Python >=3.11 — passed (`782 passed in 3.90s`).

## Known limitations

- `gitmap-cli` may remain unavailable on PyPI until the release workflow/tag is run.
- The root `gitmap` package remains a future/blocked meta-package path unless the PyPI name is transferred or explicitly re-approved.
- CI still validates the root meta-package build/install smoke as an internal package invariant, but the publish workflow no longer publishes it.

## Rollback risk

Low. This is documentation and release workflow/guardrail alignment only. Rolling back would restore the risk of recommending an unrelated `gitmap` PyPI project to users.

## Source handoff

`/Users/tr-mini/Desktop/tr-jig/specs/crons/gitmap-architect-handoff-2026-05-05.md`
