### PR TITLE
Preserve native Click errors in core CLI commands

### DIFF
--- a/apps/cli/gitmap/commands/commit.py
+++ b/apps/cli/gitmap/commands/commit.py
@@ -102,6 +102,8 @@ def commit(
             console.print()
             console.print(f"[dim]Branch '{current_branch}' updated to {new_commit.id[:8]}[/dim]")
 
+    except click.ClickException:
+        raise
     except Exception as commit_error:
         msg = f"Commit failed: {commit_error}"
         raise click.ClickException(msg) from commit_error

--- a/apps/cli/gitmap/commands/diff.py
+++ b/apps/cli/gitmap/commands/diff.py
@@ -324,6 +324,8 @@ def diff(
 
         _print_diff(map_diff, label_a, label_b, verbose, fmt, output)
 
+    except click.ClickException:
+        raise
     except Exception as diff_error:
         msg = f"Diff failed: {diff_error}"
         raise click.ClickException(msg) from diff_error

--- a/apps/cli/gitmap/commands/status.py
+++ b/apps/cli/gitmap/commands/status.py
@@ -124,6 +124,8 @@ def status(fmt: str) -> None:
         else:
             console.print("[green]Nothing to commit, working tree clean[/green]")
 
+    except click.ClickException:
+        raise
     except Exception as status_error:
         msg = f"Failed to get status: {status_error}"
         raise click.ClickException(msg) from status_error

--- a/packages/gitmap_core/tests/test_cli_error_messages.py
+++ b/packages/gitmap_core/tests/test_cli_error_messages.py
@@ -28,9 +28,15 @@ if str(_cli_dir) not in sys.path:
     sys.path.insert(0, str(_cli_dir))
 
 import gitmap_cli.commands.branch as branch_module  # noqa: E402
+import gitmap_cli.commands.commit as commit_module  # noqa: E402
+import gitmap_cli.commands.diff as diff_module  # noqa: E402
+import gitmap_cli.commands.status as status_module  # noqa: E402
 import gitmap_cli.commands.tag as tag_module  # noqa: E402
 
 branch = branch_module.branch
+commit = commit_module.commit
+diff = diff_module.diff
+status = status_module.status
 tag = tag_module.tag
 
 
@@ -66,3 +72,46 @@ def test_tag_without_name_surfaces_usage_instead_of_generic_wrapper(
     assert result.exit_code != 0
     assert "Usage: gitmap tag <name> [commit] or gitmap tag --list" in result.output
     assert "Tag operation failed:" not in result.output
+
+
+def test_status_outside_repository_surfaces_actionable_click_error(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    monkeypatch.setattr(status_module, "find_repository", lambda: None)
+
+    result = runner.invoke(status, [])
+
+    assert result.exit_code != 0
+    assert "Not a GitMap repository. Run 'gitmap init' to create one." in result.output
+    assert "Failed to get status:" not in result.output
+
+
+def test_commit_outside_repository_surfaces_actionable_click_error(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    monkeypatch.setattr(commit_module, "find_repository", lambda: None)
+
+    result = runner.invoke(commit, ["-m", "test commit"])
+
+    assert result.exit_code != 0
+    assert "Not a GitMap repository. Run 'gitmap init' to create one." in result.output
+    assert "Commit failed:" not in result.output
+
+
+def test_diff_missing_ref_surfaces_actionable_click_error(
+    monkeypatch: pytest.MonkeyPatch,
+    runner: CliRunner,
+) -> None:
+    repo = Mock()
+    repo.get_index.return_value = {"operationalLayers": []}
+    repo.list_branches.return_value = []
+    repo.get_commit.return_value = None
+    monkeypatch.setattr(diff_module, "find_repository", lambda: repo)
+
+    result = runner.invoke(diff, ["missing-branch"])
+
+    assert result.exit_code != 0
+    assert "Branch or commit not found: 'missing-branch'" in result.output
+    assert "Diff failed:" not in result.output


### PR DESCRIPTION
## Problem statement
`gitmap status`, `gitmap commit`, and `gitmap diff` wrapped intentional `click.ClickException`s with generic command prefixes. That made common user-actionable errors noisier, e.g. `Failed to get status: Not a GitMap repository...` instead of the native Click message.

## Scope / non-scope
Scope:
- Re-raise intentional `click.ClickException`s unchanged in `status`, `commit`, and `diff`.
- Add CLI regression coverage proving actionable messages are preserved and old generic wrappers are absent.

Non-scope:
- No repository semantics, diff algorithms, JSON schema, command names, help grouping, package metadata, or release workflow changes.

## Files changed
- `apps/cli/gitmap/commands/status.py`
- `apps/cli/gitmap/commands/commit.py`
- `apps/cli/gitmap/commands/diff.py`
- `packages/gitmap_core/tests/test_cli_error_messages.py`

## Verification
- `.venv/bin/python -m pytest packages/gitmap_core/tests/test_cli_error_messages.py -q` → `5 passed`
- `.venv/bin/python -m pytest packages/gitmap_core/tests/test_cli_registration.py packages/gitmap_core/tests/test_cli_error_messages.py -q` → `18 passed`
- `.venv/bin/python -m pytest packages/gitmap_core/tests -x -q` → `785 passed`
- `git diff --check` → passed

Note: running the focused test with system `python3` failed before collection because local dependencies such as `deepdiff` are not installed there; the repo `.venv` has the required test environment.

## Known limitations
- This only addresses the three high-frequency commands from the handoff. Other commands with similar generic wrappers are intentionally left for separate slices.

## Rollback risk
Low. The change only lets Click-controlled errors propagate while preserving generic wrappers for unexpected exceptions.

## Source handoff/spec
- `/Users/tr-mini/Desktop/tr-jig/specs/crons/gitmap-architect-handoff-2026-05-07.md`
- Daily contribution-discovery-and-build governor run, 2026-05-07
