### PR TITLE
Reject root release tags

### DIFF
--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -63,7 +63,6 @@ def test_release_metadata_requires_existing_readmes_and_typed_markers() -> None:
     [
         ("refs/tags/core-v1.2.3", "1.2.3"),
         ("cli-v1.2.3", "1.2.3"),
-        ("v1.2.3", "1.2.3"),
     ],
 )
 def test_validate_release_tag_accepts_matching_tags(ref_name: str, expected_version: str) -> None:
@@ -95,7 +94,12 @@ def test_validate_release_tag_accepts_matching_tags(ref_name: str, expected_vers
         (
             "v0.0.1",
             {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
-            "expected version 1.2.3",
+            "Root release tags are not published",
+        ),
+        (
+            "refs/tags/v1.2.3",
+            {"root_version": "1.2.3", "core_version": "1.2.3", "cli_version": "1.2.3"},
+            "Use core-v<version> or cli-v<version>",
         ),
         (
             "refs/heads/main",

--- a/scripts/release_checks.py
+++ b/scripts/release_checks.py
@@ -111,16 +111,20 @@ def _validate_package_metadata(pyproject: Path) -> None:
 
 def validate_release_tag(ref_name: str, state: dict[str, str | list[str]] | None = None) -> None:
     normalized_ref = ref_name.removeprefix("refs/tags/")
-    tag_match = re.fullmatch(r"(?:(core|cli)-)?v(.+)", normalized_ref)
+    root_tag_match = re.fullmatch(r"v(.+)", normalized_ref)
+    assert not root_tag_match, (
+        "Root release tags are not published by the active PyPI workflow. "
+        f"Use core-v<version> or cli-v<version> instead: {ref_name}"
+    )
+
+    tag_match = re.fullmatch(r"(core|cli)-v(.+)", normalized_ref)
     assert tag_match, (
-        "Release tag must be one of core-v<version>, cli-v<version>, or v<version>: "
-        f"{ref_name}"
+        f"Release tag must be one of core-v<version> or cli-v<version>: {ref_name}"
     )
 
     package_prefix, tag_version = tag_match.groups()
     state = state or collect_release_state()
     expected_versions = {
-        None: state["root_version"],
         "core": state["core_version"],
         "cli": state["cli_version"],
     }


### PR DESCRIPTION
## Problem statement

`scripts/release_checks.py` still accepted root release tags like `v0.7.0`, even though the active publish workflow only triggers package-specific `core-v*` and `cli-v*` tags. That could let release operators validate a tag shape that will not publish anything.

## Scope / non-scope

Scope:
- Reject root `v<version>` tags with explicit guidance to use `core-v<version>` or `cli-v<version>`.
- Keep package-specific tag validation intact for both short names and full `refs/tags/...` refs.
- Update release-check regression coverage.

Non-scope:
- No package publishing, tag creation, workflow changes, package metadata changes, credentials, or PyPI configuration.
- No changes to root/meta-package CI build validation.

## Files changed

- `scripts/release_checks.py`
- `packages/gitmap_core/tests/test_release_checks.py`

## Verification

- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests/test_release_checks.py -q` -> `11 passed`
- `/Users/tr-mini/Projects/git-map/.venv/bin/python scripts/release_checks.py --ref-name core-v0.7.0` -> passed
- `/Users/tr-mini/Projects/git-map/.venv/bin/python scripts/release_checks.py --ref-name cli-v0.7.0` -> passed
- `/Users/tr-mini/Projects/git-map/.venv/bin/python scripts/release_checks.py --ref-name v0.7.0` -> failed as expected with root-tag rejection guidance
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests -x -q` -> `785 passed`
- `git diff --check` -> passed

## Known limitations

This only tightens local/script release validation. It does not publish packages or change GitHub release/tag workflow behavior.

## Rollback risk

Low. Reverting restores the old permissive root-tag parser; runtime app behavior is unaffected.

## Source handoff

Coordinator run from `/Users/tr-mini/Desktop/tr-jig/specs/contribution-discovery-and-build-v1.md`, using Git-Map handoff `/Users/tr-mini/Desktop/tr-jig/specs/crons/gitmap-architect-handoff-2026-05-09.md`.
