### PR TITLE
Clean up CLI ruff issues

### DIFF
--- a/apps/cli/gitmap/commands/auto_pull.py
+++ b/apps/cli/gitmap/commands/auto_pull.py
@@ -205,25 +205,23 @@ def auto_pull(
 
                     # Auto-commit if enabled
                     commit_id = None
-                    if auto_commit:
-                        # Check if there are changes to commit
-                        if repo.has_uncommitted_changes():
-                            # Generate commit message
-                            if commit_message:
-                                # Replace template variables
-                                msg = commit_message.replace("{repo}", repo_name)
-                                msg = msg.replace("{date}", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-                            else:
-                                # Default commit message
-                                msg = f"Auto-pull from Portal ({datetime.now().strftime('%Y-%m-%d %H:%M:%S')})"
+                    if auto_commit and repo.has_uncommitted_changes():
+                        # Generate commit message
+                        if commit_message:
+                            # Replace template variables
+                            msg = commit_message.replace("{repo}", repo_name)
+                            msg = msg.replace("{date}", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+                        else:
+                            # Default commit message
+                            msg = f"Auto-pull from Portal ({datetime.now().strftime('%Y-%m-%d %H:%M:%S')})"
 
-                            # Create commit
-                            new_commit = repo.create_commit(
-                                message=msg,
-                                author=None,
-                                rationale=None,
-                            )
-                            commit_id = new_commit.id[:8]
+                        # Create commit
+                        new_commit = repo.create_commit(
+                            message=msg,
+                            author=None,
+                            rationale=None,
+                        )
+                        commit_id = new_commit.id[:8]
 
                     # Update progress display
                     if commit_id:

--- a/apps/cli/gitmap/commands/config.py
+++ b/apps/cli/gitmap/commands/config.py
@@ -73,18 +73,16 @@ def config(
         if (unset_production or production_branch) and not config_obj.remote:
             raise click.ClickException("No remote configured. Use 'gitmap clone' first.")
 
-        if unset_production:
-            if config_obj.remote:
-                config_obj.remote.production_branch = None
-                changes_made = True
-                console.print("[green]Production branch setting removed[/green]")
+        if unset_production and config_obj.remote:
+            config_obj.remote.production_branch = None
+            changes_made = True
+            console.print("[green]Production branch setting removed[/green]")
 
-        if production_branch:
-            if config_obj.remote:
-                config_obj.remote.production_branch = production_branch
-                changes_made = True
-                console.print(f"[green]Production branch set to '{production_branch}'[/green]")
-                console.print("[dim]Pushes to this branch will trigger notifications to all users in map groups[/dim]")
+        if production_branch and config_obj.remote:
+            config_obj.remote.production_branch = production_branch
+            changes_made = True
+            console.print(f"[green]Production branch set to '{production_branch}'[/green]")
+            console.print("[dim]Pushes to this branch will trigger notifications to all users in map groups[/dim]")
 
         if auto_visualize is not None:
             config_obj.auto_visualize = auto_visualize

--- a/apps/cli/gitmap/commands/daemon.py
+++ b/apps/cli/gitmap/commands/daemon.py
@@ -230,22 +230,21 @@ def execute_auto_pull(config: dict[str, Any], logger: logging.Logger) -> None:
 
                 # Auto-commit if enabled
                 commit_id = None
-                if auto_commit:
-                    if repo.has_uncommitted_changes():
-                        # Generate commit message
-                        if commit_message:
-                            msg = commit_message.replace("{repo}", repo_name)
-                            msg = msg.replace("{date}", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
-                        else:
-                            msg = f"Auto-pull from Portal ({datetime.now().strftime('%Y-%m-%d %H:%M:%S')})"
+                if auto_commit and repo.has_uncommitted_changes():
+                    # Generate commit message
+                    if commit_message:
+                        msg = commit_message.replace("{repo}", repo_name)
+                        msg = msg.replace("{date}", datetime.now().strftime("%Y-%m-%d %H:%M:%S"))
+                    else:
+                        msg = f"Auto-pull from Portal ({datetime.now().strftime('%Y-%m-%d %H:%M:%S')})"
 
-                        # Create commit
-                        new_commit = repo.create_commit(
-                            message=msg,
-                            author=None,
-                            rationale=None,
-                        )
-                        commit_id = new_commit.id[:8]
+                    # Create commit
+                    new_commit = repo.create_commit(
+                        message=msg,
+                        author=None,
+                        rationale=None,
+                    )
+                    commit_id = new_commit.id[:8]
 
                 # Log success
                 if commit_id:

--- a/apps/cli/gitmap/commands/diff.py
+++ b/apps/cli/gitmap/commands/diff.py
@@ -26,13 +26,8 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
-from gitmap_core.diff import diff_maps
-from gitmap_core.diff import format_diff_html
-from gitmap_core.diff import format_diff_stats
-from gitmap_core.diff import format_diff_summary
-from gitmap_core.diff import format_diff_visual
-from gitmap_core.repository import find_repository
-from gitmap_core.repository import Repository
+from gitmap_core.diff import diff_maps, format_diff_html, format_diff_stats, format_diff_summary, format_diff_visual
+from gitmap_core.repository import Repository, find_repository
 
 console = Console()
 

--- a/apps/cli/gitmap/commands/layer-settings-merge.py
+++ b/apps/cli/gitmap/commands/layer-settings-merge.py
@@ -537,9 +537,8 @@ def layer_settings_merge(
         current_repo = find_repository()
 
         # Only require repository if not using folder options
-        if not local_folder and not remote_folder:
-            if not current_repo:
-                raise click.ClickException("Not a GitMap repository")
+        if not local_folder and not remote_folder and not current_repo:
+            raise click.ClickException("Not a GitMap repository")
 
         # Resolve source map
         console.print(f"[dim]Resolving source: {source}[/dim]")
@@ -877,7 +876,7 @@ def _resolve_folder_id(
     if len(folder_identifier) > 8 and " " not in folder_identifier:
         # Try using it as a folder ID first
         try:
-            items = user.items(folder=folder_identifier)
+            user.items(folder=folder_identifier)
             # If this works, it's a valid folder ID
             return folder_identifier
         except Exception:
@@ -1299,7 +1298,7 @@ def _transfer_to_remote_folder(
             # Pull latest from Portal to ensure main is up to date
             try:
                 remote_ops = RemoteOperations(repo, connection)
-                portal_map_data = remote_ops.pull("main")
+                remote_ops.pull("main")
                 # If index changed, commit to main
                 if repo.has_uncommitted_changes():
                     repo.create_commit(

--- a/apps/cli/gitmap/commands/merge-from.py
+++ b/apps/cli/gitmap/commands/merge-from.py
@@ -148,10 +148,7 @@ def merge_from(
         if merge_result.has_conflicts:
             # Separate table conflicts from layer conflicts
             merged_tables = merge_result.merged_data.get("tables", [])
-            merged_layers = merge_result.merged_data.get("operationalLayers", [])
-
             table_ids = {table.get("id") for table in merged_tables if table.get("id")}
-            layer_ids = {layer.get("id") for layer in merged_layers if layer.get("id")}
 
             table_conflicts = [c for c in merge_result.conflicts if c.layer_id in table_ids]
             layer_conflicts = [c for c in merge_result.conflicts if c.layer_id not in table_ids]

--- a/apps/cli/gitmap/commands/merge.py
+++ b/apps/cli/gitmap/commands/merge.py
@@ -155,10 +155,7 @@ def merge(
             # Separate table conflicts from layer conflicts
             # Check merged_data to see which conflicts are tables vs layers
             merged_tables = merge_result.merged_data.get("tables", [])
-            merged_layers = merge_result.merged_data.get("operationalLayers", [])
-
             table_ids = {table.get("id") for table in merged_tables if table.get("id")}
-            layer_ids = {layer.get("id") for layer in merged_layers if layer.get("id")}
 
             # A conflict could be in either, but check tables first (more specific)
             table_conflicts = [c for c in merge_result.conflicts if c.layer_id in table_ids]

--- a/apps/cli/gitmap/commands/setup_repos.py
+++ b/apps/cli/gitmap/commands/setup_repos.py
@@ -179,7 +179,6 @@ def setup_repos(
             for idx, webmap_info in enumerate(webmaps, 1):
                 item_id = webmap_info.get("id", "")
                 title = webmap_info.get("title", "Unknown")
-                map_owner = webmap_info.get("owner", "")
 
                 task = progress.add_task(f"[{idx}/{len(webmaps)}] Cloning '{title}'...", total=None)
 


### PR DESCRIPTION
## Summary
- removes dead assignments in CLI command modules
- simplifies ruff-flagged nested conditions without changing behavior
- formats the touched CLI command files so the CI ruff job passes

## Validation
- `.venv/bin/python -m pytest` — 785 passed
- `/opt/homebrew/bin/ruff check packages/gitmap_core/ apps/cli/gitmap/ --select E,F,B,W --ignore E501,E741,F841,W293`
- `/opt/homebrew/bin/ruff format --check packages/gitmap_core/ apps/cli/gitmap/`
- GitHub Actions: lint, docs, Python 3.11/3.12/3.13/3.14 tests, and package validation all passed

## Notes
Running local ruff without the CI ignore list still reports broader pre-existing style debt outside this focused cleanup scope.