### PR TITLE
Sync roadmap with shipped foundation

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -4,21 +4,26 @@
 
 **Goal:** Community adoption — get real users.
 
+## Shipped Foundation
+
+- README overhaul with install, source install, quickstart, examples, and demo workflow.
+- PyPI packaging and release guardrails for `gitmap`.
+- CI smoke/package checks for built distributions.
+- CLI error-message polish and ruff cleanup.
+- Documentation pages for installation, quickstart, commands, and diff review.
+- Landing page with value proposition and install instructions.
+- Branch/JSON diff foundations for reviewable map-state changes.
+
 ## Priority Queue (architect picks top incomplete item)
 
-1. README overhaul — installation guide, quickstart tutorial, GIF/video demos showing core workflows
-2. PyPI publish — `pip install gitmap`, proper package metadata, badges
-3. CLI polish — better error messages, help text, colored output
-4. CI/CD pipeline — GitHub Actions for tests on every PR
-5. Documentation site — mkdocs with tutorials, API reference, examples
-6. Landing page on ingramgeoai.com with value prop + install instructions
-7. Demo video for portfolio (60-90 sec showing commit/branch/revert workflow)
-8. Branch diff visualization — visual comparison of map states
-9. ArcGIS Pro integration — Python toolbox wrapper
-10. Blog post / r/gis launch strategy
+1. Demo video for portfolio — 60-90 seconds showing clone, commit, branch, diff, merge, and revert workflow.
+2. Branch diff visualization — visual comparison of map states beyond current structured JSON diff foundations.
+3. ArcGIS Pro integration — Python toolbox wrapper for desktop GIS users.
+4. Blog post / r/gis launch strategy — adoption push after demo/video assets are ready.
+5. Real-user validation — run a low-risk test with a GIS user and record onboarding friction.
 
 ## Constraints
 - Python package, keep dependencies minimal
 - All work on `jig/*` branches, PRs to main
-- Tests must pass before PR (currently 450+)
+- Tests must pass before PR
 - No breaking changes to existing CLI interface


### PR DESCRIPTION
## Problem
The Git-Map roadmap still listed README, PyPI, CI, landing page, CLI polish, and diff foundations as future work even though recent merged PRs shipped those foundations. That stale queue can cause the contribution governor to rediscover completed slices.

## Scope
- Adds a Shipped Foundation section to roadmap.md.
- Replaces completed foundation items with the next adoption-focused queue: demo video, branch diff visualization, ArcGIS Pro wrapper, launch strategy, and real-user validation.
- Removes the stale numeric test-count claim from constraints.

## Non-scope
- No CLI, package, docs-site, landing-page, CI, or release behavior changes.
- No roadmap churn outside the current shipped/future split.

## Verification
- rg confirmed shipped foundation, next priority, real-user validation, and test constraint language.
- git diff --check passed for roadmap.md.

## Test note
- Attempted a focused pytest command in the clean worktree, but no local .venv exists and system python lacks pytest. No package install was performed.