### PR TITLE
fix(openclaw): normalize GitMap integration paths

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -4,10 +4,11 @@ OpenClaw plugin for Git-Map version control. Provides 8 tools for managing ArcGI
 
 ## Prerequisites
 
-- **Git-Map installed** — `~/Desktop/Git-Map` with packages installed:
+- **Git-Map installed** — this repository checkout, or another checkout pointed to by `GITMAP_ROOT`:
   ```bash
-  pip install -e ~/Desktop/Git-Map/packages/gitmap_core
-  pip install -e ~/Desktop/Git-Map/apps/cli/gitmap
+  export GITMAP_ROOT="/path/to/git-map"  # optional when running from this integration directory
+  pip install -e "$GITMAP_ROOT/packages/gitmap_core"
+  pip install -e "$GITMAP_ROOT/apps/cli/gitmap"
   ```
 
 - **OpenClaw installed** — Gateway running with plugin support
@@ -23,7 +24,8 @@ OpenClaw plugin for Git-Map version control. Provides 8 tools for managing ArcGI
 
 1. **Start the GitMap skill server:**
    ```bash
-   cd ~/Desktop/Git-Map/integrations/openclaw
+   cd /path/to/git-map/integrations/openclaw
+   export GITMAP_ROOT="$(cd ../.. && pwd)"
    python3 server.py
    ```
    Or use the installer script:
@@ -58,9 +60,14 @@ OpenClaw plugin for Git-Map version control. Provides 8 tools for managing ArcGI
 
 | Variable | Description |
 |----------|-------------|
+| `GITMAP_ROOT` | GitMap source checkout used by local fallback imports; optional when the server runs from this repo |
 | `PORTAL_URL` | ArcGIS Portal or AGOL URL (required) |
 | `ARCGIS_USERNAME` | Portal username |
 | `ARCGIS_PASSWORD` | Portal password |
+
+The OpenClaw plugin schema also supports `serverUrl` for pointing the TypeScript
+plugin at a non-default GitMap skill server URL. The default is
+`http://localhost:7400`.
 
 Alternatively, pass credentials directly to tools as parameters.
 
@@ -85,6 +92,7 @@ Alternatively, pass credentials directly to tools as parameters.
 
 ## Troubleshooting
 
-- **Server not starting**: Check Python dependencies are installed
+- **Server not starting**: Check Python dependencies are installed and `GITMAP_ROOT` points at a valid GitMap checkout if you are not running from this repository
+- **Wrong repo path**: OpenClaw sends `repo_path`; the Python server normalizes it to the CLI wrapper `cwd` parameter
 - **Tools not working**: Ensure `PORTAL_URL` is set and credentials are valid
 - **Plugin not loading**: Run `openclaw plugins list` to verify installation

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -1,12 +1,21 @@
 /**
  * Git-Map OpenClaw Plugin
- * Proxies tool calls to the gitmap-skill Python server on port 7400.
+ * Proxies tool calls to the gitmap-skill Python server on port 7400 by default.
  */
 
-const SERVER_URL = "http://localhost:7400";
+const DEFAULT_SERVER_URL = "http://localhost:7400";
 
-async function callTool(name: string, args: Record<string, unknown>) {
-  const res = await fetch(`${SERVER_URL}/tools/${name}`, {
+function getServerUrl(api: any): string {
+  const config = api?.config ?? api?.getConfig?.() ?? {};
+  const configuredUrl = config?.serverUrl;
+
+  return typeof configuredUrl === "string" && configuredUrl.length > 0
+    ? configuredUrl
+    : DEFAULT_SERVER_URL;
+}
+
+async function callTool(serverUrl: string, name: string, args: Record<string, unknown>) {
+  const res = await fetch(`${serverUrl}/tools/${name}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(args),
@@ -17,6 +26,8 @@ async function callTool(name: string, args: Record<string, unknown>) {
 }
 
 export default function (api: any) {
+  const serverUrl = getServerUrl(api);
+
   api.registerTool(
     {
       name: "gitmap_list",
@@ -31,7 +42,7 @@ export default function (api: any) {
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_list", params);
+        return callTool(serverUrl, "gitmap_list", params);
       },
     },
     { optional: true },
@@ -48,7 +59,7 @@ export default function (api: any) {
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_status", params);
+        return callTool(serverUrl, "gitmap_status", params);
       },
     },
     { optional: true },
@@ -68,7 +79,7 @@ export default function (api: any) {
         required: ["message"],
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_commit", params);
+        return callTool(serverUrl, "gitmap_commit", params);
       },
     },
     { optional: true },
@@ -88,7 +99,7 @@ export default function (api: any) {
         required: ["action"],
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_branch", params);
+        return callTool(serverUrl, "gitmap_branch", params);
       },
     },
     { optional: true },
@@ -107,7 +118,7 @@ export default function (api: any) {
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_diff", params);
+        return callTool(serverUrl, "gitmap_diff", params);
       },
     },
     { optional: true },
@@ -124,7 +135,7 @@ export default function (api: any) {
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_push", params);
+        return callTool(serverUrl, "gitmap_push", params);
       },
     },
     { optional: true },
@@ -141,7 +152,7 @@ export default function (api: any) {
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_pull", params);
+        return callTool(serverUrl, "gitmap_pull", params);
       },
     },
     { optional: true },
@@ -160,7 +171,7 @@ export default function (api: any) {
         },
       },
       async execute(_id: string, params: Record<string, unknown>) {
-        return callTool("gitmap_log", params);
+        return callTool(serverUrl, "gitmap_log", params);
       },
     },
     { optional: true },

--- a/integrations/openclaw/install.sh
+++ b/integrations/openclaw/install.sh
@@ -3,10 +3,23 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITMAP_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LOG_DIR="${OPENCLAW_STATE_DIR:-$HOME/.openclaw}/logs"
 
-echo "Starting gitmap-skill server..."
-nohup python3 "$SCRIPT_DIR/server.py" > ~/.openclaw/logs/gitmap-skill.log 2>&1 &
-echo $! > "$SCRIPT_DIR/server.pid"
+mkdir -p "$LOG_DIR"
+
+if [ -f "$SCRIPT_DIR/server.pid" ] && kill -0 "$(cat "$SCRIPT_DIR/server.pid")" 2>/dev/null; then
+    echo "gitmap-skill server already running with pid $(cat "$SCRIPT_DIR/server.pid")"
+else
+    echo "Starting gitmap-skill server..."
+    if command -v uv >/dev/null 2>&1; then
+        GITMAP_ROOT="$GITMAP_ROOT" nohup uv run --no-project --with deepdiff --with rich --with click \
+            python "$SCRIPT_DIR/server.py" > "$LOG_DIR/gitmap-skill.log" 2>&1 &
+    else
+        GITMAP_ROOT="$GITMAP_ROOT" nohup "${PYTHON_BIN:-python3}" "$SCRIPT_DIR/server.py" > "$LOG_DIR/gitmap-skill.log" 2>&1 &
+    fi
+    echo $! > "$SCRIPT_DIR/server.pid"
+fi
 
 echo "Installing OpenClaw plugin..."
 openclaw plugins install -l "$SCRIPT_DIR"

--- a/integrations/openclaw/server.py
+++ b/integrations/openclaw/server.py
@@ -112,6 +112,40 @@ TOOL_REGISTRY = {
 }
 
 
+# ---- Parameter compatibility ----------------------------------------------------------
+def normalize_tool_params(tool_name: str, params: dict) -> dict:
+    """
+    Normalize OpenClaw plugin parameters to the Python tool function API.
+
+    Args:
+        tool_name: Tool being called.
+        params: Raw JSON body from the OpenClaw plugin.
+
+    Returns:
+        dict: Parameters safe to pass to the target Python tool function.
+    """
+    normalized = dict(params)
+
+    repo_path = normalized.pop("repo_path", None)
+    if repo_path is not None and "cwd" not in normalized:
+        normalized["cwd"] = repo_path
+
+    if tool_name == "gitmap_branch":
+        action = normalized.pop("action", None)
+        if action == "delete":
+            normalized["delete"] = True
+        elif action in {"list", "create", None}:
+            normalized.pop("delete", None)
+
+    if tool_name == "gitmap_diff":
+        target = normalized.pop("target", None)
+        normalized.pop("verbose", None)
+        if target and "branch" not in normalized and "commit" not in normalized:
+            normalized["branch"] = target
+
+    return normalized
+
+
 # ---- HTTP Handler --------------------------------------------------------------------
 
 class GitMapHandler(BaseHTTPRequestHandler):
@@ -189,7 +223,7 @@ class GitMapHandler(BaseHTTPRequestHandler):
             )
             return
 
-        params = self.read_body()
+        params = normalize_tool_params(tool_name, self.read_body())
         tool_fn = TOOL_REGISTRY[tool_name]["fn"]
 
         try:

--- a/integrations/openclaw/tests/test_tools.py
+++ b/integrations/openclaw/tests/test_tools.py
@@ -14,16 +14,62 @@ from __future__ import annotations
 
 import importlib.util
 import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 TOOLS_PATH = Path(__file__).resolve().parents[1] / "tools.py"
+SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
 TOOLS_SPEC = importlib.util.spec_from_file_location("gitmap_openclaw_tools", TOOLS_PATH)
 gitmap_tools = importlib.util.module_from_spec(TOOLS_SPEC)
 assert TOOLS_SPEC.loader is not None
 TOOLS_SPEC.loader.exec_module(gitmap_tools)
+
+SERVER_SPEC = importlib.util.spec_from_file_location("gitmap_openclaw_server", SERVER_PATH)
+gitmap_server = importlib.util.module_from_spec(SERVER_SPEC)
+assert SERVER_SPEC.loader is not None
+SERVER_SPEC.loader.exec_module(gitmap_server)
+
+
+class TestGitmapRoot:
+    """Tests for GitMap source tree discovery."""
+
+    def test_default_root_is_current_repository(self) -> None:
+        """Default fallback resolves to the checked-out GitMap repository."""
+        repo_root = Path(__file__).resolve().parents[3]
+
+        assert repo_root == gitmap_tools.GITMAP_CLI_DIR
+
+
+class TestServerParameterNormalization:
+    """Tests for OpenClaw plugin parameter compatibility."""
+
+    def test_repo_path_is_normalized_to_cwd(self) -> None:
+        """OpenClaw's repo_path parameter is accepted by Python tools as cwd."""
+        params = gitmap_server.normalize_tool_params(
+            "gitmap_status",
+            {"repo_path": "/tmp/map-repo"},
+        )
+
+        assert params == {"cwd": "/tmp/map-repo"}
+
+    def test_branch_action_delete_is_normalized(self) -> None:
+        """OpenClaw's branch action enum maps to Python branch arguments."""
+        params = gitmap_server.normalize_tool_params(
+            "gitmap_branch",
+            {"repo_path": "/tmp/map-repo", "action": "delete", "name": "old"},
+        )
+
+        assert params == {"cwd": "/tmp/map-repo", "name": "old", "delete": True}
+
+    def test_diff_target_is_normalized_to_branch(self) -> None:
+        """OpenClaw's diff target parameter maps to the Python branch parameter."""
+        params = gitmap_server.normalize_tool_params(
+            "gitmap_diff",
+            {"repo_path": "/tmp/map-repo", "target": "main", "verbose": True},
+        )
+
+        assert params == {"cwd": "/tmp/map-repo", "branch": "main"}
 
 
 # ---- _find_gitmap() ------------------------------------------------------------------
@@ -40,12 +86,10 @@ class TestFindGitmap:
 
     def test_falls_back_to_main_py_when_not_in_path(self, tmp_path: Path) -> None:
         """Falls back to python main.py when gitmap not in PATH."""
-        # Patch shutil.which: gitmap absent, python3 present
+        # Patch shutil.which: gitmap absent; fallback should use current Python.
         def which_side_effect(name: str):
             if name == "gitmap":
                 return None
-            if name == "python3":
-                return "/usr/bin/python3"
             return None
 
         # Patch GITMAP_CLI_DIR so the main.py path exists
@@ -57,7 +101,7 @@ class TestFindGitmap:
              patch.object(gitmap_tools, "GITMAP_CLI_DIR", tmp_path):
             result = gitmap_tools._find_gitmap()
 
-        assert "/usr/bin/python3" in result[0]
+        assert result[0] == sys.executable
         assert str(fake_main) in result[-1]
 
     def test_falls_back_to_module_when_main_py_missing(self) -> None:
@@ -150,6 +194,15 @@ class TestRun:
         mock_run.assert_called_once()
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["cwd"] == str(tmp_path)
+
+    def test_adds_gitmap_paths_to_pythonpath(self) -> None:
+        """Fallback CLI subprocesses can import gitmap_core from the source tree."""
+        with patch("subprocess.run", return_value=self._mock_completed_process()) as mock_run:
+            gitmap_tools._run(["status"])
+
+        pythonpath = mock_run.call_args[1]["env"]["PYTHONPATH"]
+        assert str(gitmap_tools.GITMAP_CLI_DIR / "packages") in pythonpath
+        assert str(gitmap_tools.GITMAP_CLI_DIR / "apps" / "cli") in pythonpath
 
     def test_merges_extra_env(self) -> None:
         """Extra environment variables are merged into the subprocess env."""

--- a/integrations/openclaw/tools.py
+++ b/integrations/openclaw/tools.py
@@ -10,8 +10,8 @@ Key Features:
     - Returns dict with stdout, stderr, returncode, and parsed data
 
 Dependencies:
-    - gitmap CLI (pip install -e ~/Desktop/Git-Map/apps/cli/gitmap)
-    - gitmap_core (pip install -e ~/Desktop/Git-Map/packages/gitmap_core)
+    - gitmap CLI (pip install -e $GITMAP_ROOT/apps/cli/gitmap)
+    - gitmap_core (pip install -e $GITMAP_ROOT/packages/gitmap_core)
 
 Metadata:
     Author: OpenClaw
@@ -21,16 +21,34 @@ Metadata:
 from __future__ import annotations
 
 import os
-import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Optional
 
 
 # ---- Constants -----------------------------------------------------------------------
+def _default_gitmap_root() -> Path:
+    """
+    Resolve the GitMap source tree used by local fallback imports.
 
-GITMAP_CLI_DIR = Path.home() / "Desktop" / "Git-Map"
+    Returns:
+        Path: GitMap repository root, preferring GITMAP_ROOT when set and
+            otherwise walking upward from this integration directory.
+    """
+    configured_root = os.environ.get("GITMAP_ROOT")
+    if configured_root:
+        return Path(configured_root).expanduser().resolve()
+
+    for candidate in Path(__file__).resolve().parents:
+        if (candidate / "apps" / "cli" / "gitmap").exists() and (candidate / "packages" / "gitmap_core").exists():
+            return candidate
+
+    return Path.home() / "Desktop" / "Git-Map"
+
+
+GITMAP_CLI_DIR = _default_gitmap_root()
 GITMAP_CORE_PKG = str(GITMAP_CLI_DIR / "packages" / "gitmap_core")
 GITMAP_CLI_PKG = str(GITMAP_CLI_DIR / "apps" / "cli" / "gitmap")
 
@@ -49,8 +67,9 @@ def _find_gitmap() -> list[str]:
     if shutil.which("gitmap"):
         return ["gitmap"]
 
-    # Fallback: run as Python module from the source directory
-    python = shutil.which("python3") or shutil.which("python") or "python3"
+    # Fallback: run as Python module from the source directory using the
+    # interpreter that is running the skill server so installed dependencies match.
+    python = sys.executable or shutil.which("python3") or shutil.which("python") or "python3"
     main_py = GITMAP_CLI_DIR / "apps" / "cli" / "gitmap" / "main.py"
     if main_py.exists():
         return [python, str(main_py)]
@@ -81,6 +100,14 @@ def _run(
     full_cmd = cmd_prefix + args
 
     env = os.environ.copy()
+    gitmap_python_paths = [
+        str(GITMAP_CLI_DIR / "packages"),
+        str(GITMAP_CLI_DIR / "apps" / "cli"),
+    ]
+    existing_pythonpath = env.get("PYTHONPATH")
+    if existing_pythonpath:
+        gitmap_python_paths.append(existing_pythonpath)
+    env["PYTHONPATH"] = os.pathsep.join(gitmap_python_paths)
     if extra_env:
         env.update(extra_env)
 
@@ -188,10 +215,10 @@ def gitmap_list(
     """
     import sys
 
-    # Add Git-Map packages to path
-    gitmap_dir = os.path.expanduser("~/Desktop/Git-Map")
-    sys.path.insert(0, os.path.join(gitmap_dir, "packages"))
-    sys.path.insert(0, os.path.join(gitmap_dir, "apps", "cli"))
+    # Add GitMap packages to path
+    gitmap_dir = GITMAP_CLI_DIR
+    sys.path.insert(0, str(gitmap_dir / "packages"))
+    sys.path.insert(0, str(gitmap_dir / "apps" / "cli"))
 
     try:
         from gitmap_core.connection import get_connection
@@ -418,10 +445,10 @@ def gitmap_log(
     """
     import sys
 
-    # Add Git-Map packages to path
-    gitmap_dir = os.path.expanduser("~/Desktop/Git-Map")
-    sys.path.insert(0, os.path.join(gitmap_dir, "packages"))
-    sys.path.insert(0, os.path.join(gitmap_dir, "apps", "cli"))
+    # Add GitMap packages to path
+    gitmap_dir = GITMAP_CLI_DIR
+    sys.path.insert(0, str(gitmap_dir / "packages"))
+    sys.path.insert(0, str(gitmap_dir / "apps" / "cli"))
 
     try:
         from gitmap_core.repository import find_repository


### PR DESCRIPTION
## Summary
- Removes hardcoded `~/Desktop/Git-Map` assumptions from the OpenClaw integration path handling
- Adds `GITMAP_ROOT` discovery and passes source-tree paths through `PYTHONPATH` for fallback CLI subprocesses
- Normalizes OpenClaw plugin parameters (`repo_path`, branch `action`, diff `target`) before calling Python tool wrappers
- Uses the plugin `serverUrl` config when present instead of always hardcoding localhost
- Updates installer/docs for idempotent startup and configurable paths
- Adds OpenClaw integration tests for root discovery, parameter normalization, and fallback Python path propagation

## Validation
- `pytest integrations/openclaw/tests/test_tools.py -q` ✅ 37 passed
- `git diff --check` ✅
- `python -m py_compile integrations/openclaw/server.py integrations/openclaw/tools.py` ✅
- `mkdocs build --strict` ✅
- CI-equivalent lint/format subset for core/CLI ✅
- `uv run --no-project --with pytest --with deepdiff --with rich --with click --with pyyaml --with packaging --with tomli --with pytest-cov env PYTHONPATH=packages:apps/cli python -m pytest packages/gitmap_core/tests -q --tb=short` ✅ 785 passed
- Local OpenClaw server smoke:
  - `GET /health` ✅
  - `GET /tools` returned 8 tools ✅
  - `POST /tools/gitmap_status` with `repo_path` returned a structured GitMap error instead of hanging ✅

## Notes
Local status smoke reports "Not a GitMap repository" for `/Users/tr-mini/Projects/git-map`, which is expected because that checkout is the GitMap source repo, not an initialized map repository.