### PR TITLE
docs: improve first-user quickstart safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install -e apps/cli/gitmap
 
 ## Quickstart: first successful workflow
 
-This walkthrough starts with an existing ArcGIS web map and finishes by pushing an approved main-branch state back to Portal.
+This walkthrough starts with an existing ArcGIS web map and finishes by pushing an approved main-branch state back to Portal. For your first run, use a non-production test web map that you own or can safely modify.
 
 ### 1. Configure Portal credentials
 
@@ -123,6 +123,10 @@ ARCGIS_PASSWORD=your_password
 
 Copy the web map item ID from ArcGIS Online or Portal, then clone it:
 
+- Open the web map item page in ArcGIS Online or Portal.
+- Copy the `id` value from the URL, such as `...?id=abc123def456`.
+- Use a test map first. `clone`, `status`, `diff`, `log`, and `commit` work locally, but `push` can update ArcGIS content.
+
 ```bash
 gitmap clone abc123def456
 cd YourMapTitle
@@ -134,6 +138,8 @@ To choose the local folder name yourself:
 gitmap clone abc123def456 --directory flood-risk-map
 cd flood-risk-map
 ```
+
+The clone command creates a local GitMap repository containing the web map JSON, GitMap metadata, and an initial commit for the current Portal state. It does not modify the Portal item.
 
 ### 3. Check the starting state
 
@@ -193,6 +199,8 @@ gitmap checkout main
 gitmap merge feature/hydrology-update
 gitmap push
 ```
+
+`gitmap push` publishes the current branch state back to the configured ArcGIS item or Portal-managed GitMap item, depending on repository configuration. Review diffs before pushing, and use a test web map until you are comfortable with the workflow.
 
 That is the core GitMap loop: **clone → branch → pull or edit → diff → commit → merge → push**.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -4,6 +4,7 @@
 
 - Python 3.11, 3.12, 3.13, or 3.14
 - ArcGIS Online account **or** Portal for ArcGIS 10.8+
+- A non-production test web map for your first clone/push workflow
 
 ## Install from PyPI
 
@@ -18,6 +19,8 @@ Verify the install:
 ```bash
 gitmap --version
 ```
+
+If the command is not found, confirm the Python environment's `bin` directory is on your `PATH`, or run GitMap from the same virtual environment where you installed `gitmap-cli`.
 
 !!! tip "Individual packages"
     If you only need the library (no CLI), install `gitmap-core` directly.
@@ -51,6 +54,8 @@ Git-Map reads credentials from environment variables when no config is set:
 | `PORTAL_URL` | Your Portal URL (defaults to `https://www.arcgis.com`) |
 
 You can also store credentials in the repository config file — see [Working with Portals](../guides/portals.md).
+
+Do not commit `.env` files or credentials. GitMap commands such as `status`, `diff`, `log`, and `commit` operate on the local repository, while `pull` reads from ArcGIS and `push` can update ArcGIS content.
 
 ## Upgrading
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -2,6 +2,8 @@
 
 Get from zero to your first committed map version in under 5 minutes.
 
+For the first run, use a non-production test web map that you own or can safely modify. Most GitMap commands are local-only, but `gitmap push` can update ArcGIS content.
+
 ## Prerequisites
 
 Make sure you have gitmap installed:
@@ -10,6 +12,8 @@ Make sure you have gitmap installed:
 pip install gitmap-cli
 gitmap --version
 ```
+
+You also need an ArcGIS Online or Portal web map item ID. Open the web map item page and copy the `id` value from the URL, such as `...?id=abc123def456`.
 
 ## 1. Set Up Credentials
 
@@ -39,7 +43,7 @@ cd YourMapTitle
 
 Replace `abc123def456` with your web map's item ID (visible in the Portal URL).
 
-This creates a local repository with the map's current state as the initial commit.
+This creates a local repository with the map's current state as the initial commit. The local folder contains GitMap metadata and tracked web map JSON. Cloning reads from Portal; it does not change the Portal item.
 
 ## 3. Check Status
 
@@ -55,6 +59,8 @@ Expected output:
 ╰─────────────────╯
 Nothing to commit, working tree clean
 ```
+
+If you see an error here, check that you are inside the folder created by `gitmap clone` and that the clone completed successfully.
 
 ## 4. Create a Branch and Experiment
 
@@ -112,7 +118,15 @@ gitmap merge feature/new-basemap
 gitmap push
 ```
 
-The map is now live in Portal.
+`gitmap push` is the step that can update ArcGIS content. Review the diff before pushing, and keep using a test map until the workflow is familiar.
+
+## First-Run Troubleshooting
+
+- Missing credentials: set `ARCGIS_USERNAME`, `ARCGIS_PASSWORD`, and `PORTAL_URL`, or create a local `.env` file.
+- Missing command: install with `pip install gitmap-cli`, then run `gitmap --version`.
+- Wrong item ID: copy the web map item ID from the ArcGIS item page URL, not the map title or layer ID.
+- Wrong directory: run GitMap commands from the folder created by `gitmap clone`.
+- Permission denied: confirm your ArcGIS account can read the map and can edit it before trying `gitmap push`.
 
 ---
 

--- a/docs/guides/portals.md
+++ b/docs/guides/portals.md
@@ -49,6 +49,8 @@ When you `push`, Git-Map creates a `GitMap` folder in your Portal content and na
 
 This keeps branches organized and easy to find.
 
+For first-time testing, use a non-production web map and confirm your account has the expected item permissions. `gitmap clone` reads the current web map into a local repository, while `gitmap push` can publish the current branch state back to ArcGIS-managed content.
+
 ## Notifications
 
 When pushing to the configured production branch, Git-Map can send Portal notifications to all users in groups that have access to the map. Use `--no-notify` to suppress this.


### PR DESCRIPTION
## Summary
- Add first-run safety guidance to use a non-production/test web map
- Clarify where to find ArcGIS web map item IDs and what clone creates locally
- Explain which commands are local-only vs which can read from or update ArcGIS
- Add first-run troubleshooting for credentials, install/PATH, wrong item IDs, wrong directories, and permissions

## Validation
- .venv/bin/gitmap --version
- .venv/bin/mkdocs build --strict
- git diff --check