### PR TITLE
docs: align first-user safety guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ pip install -e apps/cli/gitmap
 
 This walkthrough starts with an existing ArcGIS web map and finishes by pushing an approved main-branch state back to Portal. For your first run, use a non-production test web map that you own or can safely modify.
 
+Before you start, verify that the item ID comes from the ArcGIS web map item URL and that the map is safe to test against. `gitmap clone` reads from Portal and creates a local repository; `gitmap push` is the step that can update ArcGIS-managed content.
+
 ### 1. Configure Portal credentials
 
 GitMap can read credentials from environment variables or from a local `.env` file. The repo includes a template:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -4,6 +4,16 @@ Get from zero to your first committed map version in under 5 minutes.
 
 For the first run, use a non-production test web map that you own or can safely modify. Most GitMap commands are local-only, but `gitmap push` can update ArcGIS content.
 
+## First-Run Safety Checklist
+
+Before running the workflow for the first time:
+
+- Use a non-production web map that you own or can safely modify.
+- Confirm you copied the web map item ID from the ArcGIS item URL, not the map title or a layer ID.
+- Remember that `clone`, `status`, `diff`, `log`, and `commit` are local/review operations.
+- Treat `pull` as a read from ArcGIS and `push` as the step that can update ArcGIS-managed content.
+- Review `gitmap diff` before any `gitmap push`.
+
 ## Prerequisites
 
 Make sure you have gitmap installed:

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -20,9 +20,10 @@ Before posting anywhere, nail the first-impression UX:
   - Update README badge: `pip install gitmap-core`
   - Make `pip install gitmap-core && gitmap --help` work flawlessly
 
-- [ ] **Quick-start that actually works**
+- [ ] **Quick-start validation with a real user**
+  - Safety guidance and first-run troubleshooting are in place
   - Test the README quickstart on a clean machine with a real (or mock) Portal
-  - The first 5 minutes MUST work without reading docs
+  - The first 5 minutes MUST work without private coaching
 
 - [ ] **Landing page live** at ingramgeoai.com/gitmap or gitmap.io
   - One-liner value prop

--- a/roadmap.md
+++ b/roadmap.md
@@ -50,21 +50,28 @@ Shipped or substantially in place:
 **Goal:** A GIS user can try GitMap on a non-production web map in under 10
 minutes.
 
-**Status:** Next.
+**Status:** In progress / safety guidance substantially shipped; needs clean
+first-user validation.
 
-**Why it matters:** The current docs are solid, but a first-time user still
-needs more help identifying a safe map, finding an ArcGIS item ID, and
-understanding what `gitmap push` changes.
+**Why it matters:** The docs now cover the main first-run safety issues, but
+the workflow still needs validation from a clean environment and real GIS
+users.
 
-**Planned work:**
+**Shipped / substantially in place:**
 
-- Add "use a non-production test map first" guidance to the quickstart.
-- Explain where to find the web map item ID in ArcGIS Online / Portal.
-- Clarify which commands read Portal state and which commands write back to
-  Portal.
-- Add first-run troubleshooting for credentials, Portal URL, package install,
-  and missing item IDs.
+- Non-production test-map guidance in README, installation docs, quickstart,
+  and Portal docs.
+- Web map item-ID discovery guidance in README and quickstart.
+- Local/read/write command safety language, including clear `gitmap push`
+  warnings.
+- First-run troubleshooting for credentials, install/path issues, item IDs,
+  wrong directories, and permissions.
+
+**Remaining work:**
+
 - Test the quickstart on a clean machine or clean virtual environment.
+- Ask 1-3 GIS users to complete the quickstart without coaching.
+- Convert observed friction into follow-up issues.
 
 **Success signal:** A new user can complete clone, branch, pull/edit, diff,
 commit, merge, and push on a test map without private help.


### PR DESCRIPTION
Aligns first-user GitMap safety guidance across the quickstart, README, roadmap, and launch strategy. Adds a compact first-run safety checklist and updates roadmap/launch status to show docs safety guidance is substantially shipped while clean first-user validation remains next.\n\nValidation:\n- mkdocs build --strict\n- git diff --check