### PR TITLE
fix: allow single-item branch pulls

### DIFF
--- a/docs/commands/pull.md
+++ b/docs/commands/pull.md
@@ -44,3 +44,5 @@ Changes staged. Use 'gitmap diff' to review and 'gitmap commit' to save.
 
 - `pull` only updates the index. You still need to `commit` to record the version.
 - Review changes with `gitmap diff` before committing.
+- Repositories cloned from a single web map can pull the original Portal item into
+  the current local branch before any GitMap remote folder has been created.

--- a/packages/gitmap_core/remote.py
+++ b/packages/gitmap_core/remote.py
@@ -24,12 +24,12 @@ from typing import TYPE_CHECKING, Any
 from gitmap_core.communication import notify_item_group_users
 from gitmap_core.compat import create_folder as compat_create_folder
 from gitmap_core.compat import get_user_folders
-from gitmap_core.connection import PortalConnection
-from gitmap_core.models import Remote
 
 if TYPE_CHECKING:
     from arcgis.gis import GIS, Item
 
+    from gitmap_core.connection import PortalConnection
+    from gitmap_core.models import Remote
     from gitmap_core.repository import Repository
 
 
@@ -462,11 +462,12 @@ class RemoteOperations:
             prefixed_title = f"{self.config.project_name}_{item_title}"
 
             for item in items:
-                if item.type == "Web Map":
-                    if item.title == prefixed_title or item.title == item_title:
-                        # Verify it's a GitMap item by checking tags
-                        if "GitMap" in (item.tags or []):
-                            return item
+                if (
+                    item.type == "Web Map"
+                    and (item.title == prefixed_title or item.title == item_title)
+                    and "GitMap" in (item.tags or [])
+                ):
+                    return item
 
             return None
 
@@ -609,8 +610,9 @@ class RemoteOperations:
                 msg = "No remote configured"
                 raise RuntimeError(msg)
 
-            # For main branch, if we have the original item_id, pull from it directly
-            if branch == "main" and self.remote.item_id:
+            # Single-item clone workflows may not have a GitMap remote folder yet.
+            # In that case, pull the cloned Portal item into the requested local branch.
+            if self.remote.item_id and (branch == "main" or not self.remote.folder_id):
                 try:
                     original_item = self.gis.content.get(self.remote.item_id)
                     if original_item and original_item.type == "Web Map":

--- a/packages/gitmap_core/tests/test_remote.py
+++ b/packages/gitmap_core/tests/test_remote.py
@@ -1054,18 +1054,55 @@ class TestPullOperations:
         assert result == sample_map_data
         mock_repository.update_index.assert_called_once_with(sample_map_data)
 
-    def test_pull_raises_without_folder_when_not_main(
+    def test_pull_feature_branch_falls_back_to_item_without_folder(
         self,
         mock_repository: MagicMock,
         mock_connection: MagicMock,
+        sample_map_data: dict,
     ) -> None:
-        """Test pull raises error for feature branch without folder_id."""
+        """Test feature branch pull can use cloned item when no folder is configured."""
         config = RepoConfig(
             project_name="Test",
             remote=Remote(
                 name="origin",
                 url="https://test.com",
                 folder_id=None,  # No folder configured
+                item_id="original-item-id",
+            ),
+        )
+        mock_repository.get_config.return_value = config
+        mock_repository.get_current_branch.return_value = "feature/test"
+        mock_repository.get_head_commit.return_value = "commit-123"
+        mock_repository.remotes_dir = Path(tempfile.mkdtemp()) / "remotes"
+        mock_repository.remotes_dir.mkdir(parents=True)
+
+        original_item = MagicMock()
+        original_item.type = "Web Map"
+        original_item.get_data.return_value = sample_map_data
+        mock_connection.gis.content.get.return_value = original_item
+
+        ops = RemoteOperations(mock_repository, mock_connection)
+        result = ops.pull()
+
+        assert result == sample_map_data
+        mock_connection.gis.content.get.assert_called_once_with("original-item-id")
+        mock_repository.update_index.assert_called_once_with(sample_map_data)
+
+        ref_path = mock_repository.remotes_dir / "origin" / "feature_test"
+        assert ref_path.read_text() == "commit-123"
+
+    def test_pull_raises_without_folder_or_item_when_not_main(
+        self,
+        mock_repository: MagicMock,
+        mock_connection: MagicMock,
+    ) -> None:
+        """Test feature branch pull still needs a folder when no cloned item exists."""
+        config = RepoConfig(
+            project_name="Test",
+            remote=Remote(
+                name="origin",
+                url="https://test.com",
+                folder_id=None,
                 item_id=None,
             ),
         )


### PR DESCRIPTION
## Summary
- allow `gitmap pull` on feature branches to read the cloned Portal item when a repo has `remote.item_id` but no GitMap remote folder
- preserve folder-backed branch lookup behavior for configured GitMap remotes
- add regression coverage and document the single-item clone pull behavior

## Validation
- `PYTHONPATH=/Users/tr-mini/Desktop/Worktrees/git-map-pull-item-fallback/packages /Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest -x -q` -> 786 passed
- `PYTHONPATH=/Users/tr-mini/Desktop/Worktrees/git-map-pull-item-fallback/packages /Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests/test_remote.py -q` -> 105 passed
- `/opt/homebrew/bin/ruff check packages/gitmap_core/remote.py packages/gitmap_core/tests/test_remote.py` -> passed
- `/Users/tr-mini/Projects/git-map/.venv/bin/mkdocs build --strict` -> passed
- `git diff --check` -> passed

## Notes
- Bare `python` is unavailable in this cron shell, so validation used the project venv interpreter.
- Branch was published through `gh-safe api` because raw Git HTTPS push has recently hung in this cron context.
