### PR TITLE
docs: clarify safe first-run clone and pull workflow

### DIFF
--- a/docs/commands/clone.md
+++ b/docs/commands/clone.md
@@ -2,6 +2,10 @@
 
 Clone a web map from Portal into a new local repository.
 
+Use a non-production test web map for your first clone. `clone` reads the
+Portal item and creates a local GitMap repository; it does not modify the
+Portal item.
+
 ## Usage
 
 ```bash
@@ -29,7 +33,16 @@ gitmap clone abc123def456 my-project
 gitmap clone abc123def456 --url https://portal.example.com
 ```
 
+## First-run checklist
+
+1. Open the web map item page in ArcGIS Online or Portal.
+2. Copy the item ID from the URL, such as `...?id=abc123def456`.
+3. Confirm the map is safe to test against before cloning it.
+4. Configure credentials through `PORTAL_URL` and `ARCGIS_USERNAME`, or through the matching GitMap config values.
+5. Run `gitmap status` after cloning to confirm the new repository is on `main` with a clean working tree.
+
 ## Notes
 
 - `clone` initializes a new repo, connects to Portal, pulls the specified item, and creates an initial commit — all in one step.
 - Equivalent to `gitmap init && gitmap pull && gitmap commit -m "Initial clone"`.
+- The generated `.gitmap/` directory contains local repository state for the cloned map. Keep it with the project folder if you want to preserve history.

--- a/docs/commands/pull.md
+++ b/docs/commands/pull.md
@@ -2,6 +2,10 @@
 
 Fetch the latest map data from Portal and update the local staging area (index). Does not auto-commit.
 
+Use `pull` after making or reviewing a Portal-side map change that should be
+captured in your current branch. It is a Portal read operation: the local
+branch changes, but the Portal item is not updated.
+
 ## Usage
 
 ```bash
@@ -26,6 +30,19 @@ gitmap pull --url https://portal.example.com
 gitmap pull -r "Syncing production changes after client meeting"
 ```
 
+## Safe review loop
+
+```bash
+gitmap pull
+gitmap status
+gitmap diff main feature/hydrology-update --format visual
+gitmap commit -m "Update hydrology layers"
+```
+
+If you are pulling into a feature branch, review the diff against `main` before
+committing. If the diff is not what you expected, stop before `commit` and
+inspect the Portal item or local branch selection.
+
 ## Output
 
 ```
@@ -46,3 +63,4 @@ Changes staged. Use 'gitmap diff' to review and 'gitmap commit' to save.
 - Review changes with `gitmap diff` before committing.
 - Repositories cloned from a single web map can pull the original Portal item into
   the current local branch before any GitMap remote folder has been created.
+- `pull` and `push` are intentionally separate. `pull` reads from Portal into GitMap; `push` publishes a chosen branch state back to Portal.


### PR DESCRIPTION
## Summary
- Clarifies that first-time `gitmap clone` should use a non-production test web map and does not modify Portal.
- Adds a first-run clone checklist for item ID, credentials, and clean status verification.
- Adds a safe `gitmap pull` review loop and separates pull-from-Portal from push-to-Portal behavior.

## Validation
- `python -m mkdocs build --strict`
- `git diff --check`

Draft PR for review; no merge requested.
