### PR TITLE
docs: fix clone command docs on main

### DIFF
--- a/docs/commands/clone.md
+++ b/docs/commands/clone.md
@@ -9,16 +9,16 @@ Portal item.
 ## Usage
 
 ```bash
-gitmap clone [OPTIONS] ITEM_ID [PATH]
+gitmap clone [OPTIONS] ITEM_ID
 ```
 
 ## Options
 
 | Option | Short | Description |
 |--------|-------|-------------|
-| `--url` | `-u` | Portal URL |
-| `--username` | | Portal username |
-| `--branch` | `-b` | Branch name to create (default: `main`) |
+| `--directory` | `-d` | Directory to clone into (defaults to map title) |
+| `--url` | `-u` | Portal URL (defaults to ArcGIS Online) |
+| `--username` | | Portal username, or use `ARCGIS_USERNAME` |
 
 ## Examples
 
@@ -27,7 +27,7 @@ gitmap clone [OPTIONS] ITEM_ID [PATH]
 gitmap clone abc123def456
 
 # Clone to a named directory
-gitmap clone abc123def456 my-project
+gitmap clone abc123def456 --directory my-project
 
 # Clone from a specific Portal
 gitmap clone abc123def456 --url https://portal.example.com


### PR DESCRIPTION
## Summary
- update `docs/commands/clone.md` on current `main` to match live `gitmap clone --help`
- remove stale positional `[PATH]` and clone `--branch/-b` docs
- document `--directory/-d` for named clone destinations

## Verification
- `gitmap clone --help`
- static clone-doc regression check against the live help surface
- `python -m pytest packages/gitmap_core/tests/test_cli_registration.py -q` (13 passed)
- `mkdocs build --strict`
- `git diff --check`
- GitHub Actions CI is passing for lint, docs build, Python 3.11-3.14 tests, and package validation

No Portal mutation, package publish, deploy, merge, or direct push to `main`.
