### PR TITLE
docs: add first-user validation packet

### DIFF
--- a/docs/validation/feedback-questionnaire.md
+++ b/docs/validation/feedback-questionnaire.md
@@ -1,0 +1,68 @@
+# First-User Feedback Questionnaire
+
+Use this after the first-user validation test. Keep answers short and concrete.
+The best feedback names the exact instruction, command, warning, or output that
+changed the tester's confidence.
+
+## Tester Context
+
+1. What is your GIS role?
+2. Which ArcGIS environment did you use?
+3. Which operating system and shell did you use?
+4. Had you used Git, command-line GIS tools, or Python virtual environments
+   before this test?
+
+## Install And Setup
+
+1. How easy was it to install GitMap and reach `gitmap --help`?
+2. Which setup step took the longest?
+3. Were the Python and package requirements clear?
+4. Were Portal credential instructions clear enough to complete without help?
+5. What error message, if any, was hardest to understand?
+
+## Item ID And Clone
+
+1. Was it obvious where to find the ArcGIS web map item ID?
+2. Did you feel confident that the map was safe to test against?
+3. Did the clone output make it clear where the local repository was created?
+4. Was the difference between the Portal item and the local GitMap repository
+   clear?
+
+## Branch, Pull, And Diff
+
+1. Did branch creation and checkout match your expectations?
+2. Before running `gitmap pull`, did you understand that it reads from Portal
+   and updates local staged state?
+3. Which diff format did you use?
+4. Could you explain what changed from the diff output?
+5. What information was missing from the diff for a GIS review?
+
+## Commit, Merge, And Push
+
+1. Did `gitmap commit` feel like it saved the right thing?
+2. Did the merge step make sense?
+3. Before `gitmap push`, could you identify exactly which Portal item would be
+   updated?
+4. Were the push warnings strong enough?
+5. What would make you more comfortable pushing to a non-production map?
+
+## Trust And Adoption
+
+1. What was the first moment GitMap made sense?
+2. What was the first moment you stopped trusting the workflow?
+3. Would you try this again on another disposable map?
+4. What would block you from recommending GitMap to another GIS user?
+5. What one thing should GitMap improve before broader public adoption?
+
+## Issue Conversion
+
+For each problem, capture:
+
+```markdown
+- Category:
+- Command or doc page:
+- Expected result:
+- Actual result:
+- Exact error or confusing text:
+- Suggested fix:
+```

--- a/docs/validation/first-user-test.md
+++ b/docs/validation/first-user-test.md
@@ -1,0 +1,114 @@
+# First-User Validation Test
+
+Use this protocol to watch a GIS user try GitMap for the first time. The goal
+is not to prove that the user can memorize GitMap commands. The goal is to find
+where installation, Portal credentials, item IDs, diff review, and push safety
+are unclear.
+
+## Test Goal
+
+A first-time user can complete the core GitMap loop on a non-production ArcGIS
+web map:
+
+```bash
+gitmap clone <TEST_ITEM_ID> --directory gitmap-validation-map
+cd gitmap-validation-map
+gitmap branch feature/validation-change
+gitmap checkout feature/validation-change
+gitmap pull
+gitmap status
+gitmap diff main feature/validation-change --format visual
+gitmap commit -m "Validate GitMap workflow"
+gitmap checkout main
+gitmap merge feature/validation-change
+gitmap push
+```
+
+## Safety Requirements
+
+- Use only a disposable web map that the tester owns or has explicit permission
+  to modify.
+- Do not use production, customer-facing, emergency-response, billing, or
+  compliance maps.
+- Do not paste real passwords, tokens, private Portal URLs, or production item
+  IDs into notes, screenshots, recordings, GitHub issues, or PRs.
+- Stop before `gitmap push` if the tester cannot explain which Portal item will
+  be updated.
+- If the tester is unsure about credentials, item ownership, or write scope,
+  record the blocker and stop the test.
+
+## Preparation
+
+1. Create or identify a disposable ArcGIS Online or Portal web map.
+2. Confirm the tester can sign in to the ArcGIS organization in a browser.
+3. Confirm the tester can safely modify the disposable web map.
+4. Create a clean terminal session with no prior GitMap repository state.
+5. Have the tester open the GitMap README and quickstart, but do not coach the
+   command sequence unless they are blocked.
+6. Start a timer when the tester begins reading the install instructions.
+
+## Observer Checklist
+
+Record short notes for each step:
+
+| Step | Pass criteria | Notes to collect |
+|------|---------------|------------------|
+| Install | `gitmap --help` works | Python version, shell, install command, error text |
+| Credentials | GitMap connects to Portal | Env var or `.env` path used, unclear field names |
+| Item ID | Tester finds the web map item ID | Where they looked, any URL confusion |
+| Clone | Local repo is created | Output clarity, directory confusion |
+| Branch | Feature branch is active | Whether branch naming made sense |
+| Pull | Portal data reaches the index | Whether "pull is read-only" was clear |
+| Diff | Tester can describe the change | Format used, confusing fields |
+| Commit | Commit records the approved state | Message quality, rationale use |
+| Merge | Main receives the feature branch | Any Git mental-model mismatch |
+| Push | Tester knowingly updates test Portal item | Whether warning language was enough |
+
+## Friction Categories
+
+Tag each issue with one or more categories:
+
+- `install`: Python, package, PATH, shell, virtual environment.
+- `credentials`: Portal URL, username/password variables, `.env`, auth errors.
+- `item-id`: finding the web map ID or choosing the right item.
+- `working-directory`: knowing where the GitMap repo lives.
+- `branching`: understanding current branch and branch names.
+- `diff-review`: interpreting visual, JSON, or HTML diff output.
+- `push-safety`: knowing whether a command reads from or writes to Portal.
+- `docs`: unclear wording, missing examples, wrong command, stale screenshot.
+- `bug`: command fails when the tester followed the docs correctly.
+
+## Stop Conditions
+
+Stop the test and preserve notes if:
+
+- The tester would need to use a production map to continue.
+- Credentials or tokens would need to be shared with the observer.
+- `gitmap push` would update an unknown or unintended item.
+- The tester hits an unhandled exception or repeated authentication failure.
+- The observer has already coached the same step twice.
+
+## Result Summary Template
+
+```markdown
+## GitMap First-User Validation Result
+
+- Tester role:
+- Date:
+- Environment:
+- ArcGIS target: disposable test web map
+- Completed core loop: yes/no
+- Time to `gitmap --help`:
+- Time to clone:
+- Time to first diff:
+- Pushed to test item knowingly: yes/no/not attempted
+
+### Top blockers
+- [category] short description
+
+### Confusing but recoverable
+- [category] short description
+
+### Follow-up issues to create
+- [ ] title
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,9 @@ nav:
     - Branching Strategy: guides/branching.md
     - Working with Portals: guides/portals.md
     - Python API Reference: guides/api-reference.md
+  - Validation:
+    - First-User Test: validation/first-user-test.md
+    - Feedback Questionnaire: validation/feedback-questionnaire.md
   - Contributing: contributing.md
   - Technical Paper: technical-paper.md
 


### PR DESCRIPTION
## Summary

Adds the roadmap's real-user validation packet for GitMap's first-user adoption loop:

- non-production first-user validation protocol
- observer checklist and stop conditions
- short feedback questionnaire for install, credentials, item IDs, diff review, and push safety
- MkDocs navigation entries for the new validation pages

## Why

The roadmap says the next proof is not more feature work; it is observing whether a GIS analyst can complete the safe GitMap workflow and trust what will happen before any Portal write. These docs turn that into a repeatable test packet.

## Validation

- `git diff --check`
- `python -m mkdocs build --strict`
- `PYTHONPATH=... python -m pytest packages/gitmap_core/tests -x -q` -> 786 passed
- `PYTHONPATH=... python -m pytest integrations/openclaw/tests/test_tools.py integrations/arcgis_pro/test_toolbox.py -q` -> 66 passed

Note: the prompt-specified `python -m pytest tests/ -x -q` is not directly applicable in this checkout because there is no root `tests/` directory and the cron shell has no unqualified `python` binary.
