### PR TITLE
Fix quickstart diff command

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -107,7 +107,7 @@ Branch 'feature/new-basemap' updated to a3f2c1b0
 ## 6. Review What Changed
 
 ```bash
-gitmap diff --branch main
+gitmap diff main feature/new-basemap --format visual
 ```
 
 Shows a layer-by-layer comparison between your feature branch and `main`.

--- a/packages/gitmap_core/tests/test_cli_registration.py
+++ b/packages/gitmap_core/tests/test_cli_registration.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 # The package dir is named 'gitmap' but the package name is 'gitmap_cli' (via pyproject.toml mapping)
 # When not pip-installed, we register it manually as a module alias
 import os
+import re
 import subprocess
 import sys
 import types
@@ -194,6 +195,22 @@ class TestCommandRegistration:
         assert "Try 'gitmap --help' for help." in combined_output
         assert "Run 'gitmap --help' to see the full command list." in combined_output
         assert "Try 'main.py --help' for help." not in combined_output
+
+    def test_documented_diff_options_exist_in_cli_help(self, runner: CliRunner) -> None:
+        """Documented gitmap diff examples should not mention stale options."""
+        repo_root = Path(__file__).resolve().parents[3]
+        diff_help = runner.invoke(cli, ["diff", "--help"])
+        assert diff_help.exit_code == 0, f"diff --help failed:\n{diff_help.output}"
+
+        documented_options: set[str] = set()
+        for doc_path in (repo_root / "docs").rglob("*.md"):
+            for line in doc_path.read_text(encoding="utf-8").splitlines():
+                if not line.strip().startswith("gitmap diff"):
+                    continue
+                documented_options.update(re.findall(r"(?<!\\w)--[a-z][a-z-]*", line))
+
+        missing = sorted(option for option in documented_options if option not in diff_help.output)
+        assert not missing, f"Documented gitmap diff options missing from CLI help: {missing}"
 
     @pytest.mark.parametrize(
         ("mistyped", "expected"),


### PR DESCRIPTION
## Summary
- Replace the stale quickstart gitmap diff --branch example with supported positional refs.
- Add docs/CLI parity coverage that checks documented gitmap diff options against live diff help.

## Verification
- PYTHONPATH=packages:apps/cli/gitmap /Users/tr-mini/Projects/git-map/.venv/bin/pytest packages/gitmap_core/tests/test_cli_registration.py -q
- PYTHONPATH=packages:apps/cli/gitmap /Users/tr-mini/Projects/git-map/.venv/bin/pytest packages/gitmap_core/tests/test_cli_registration.py packages/gitmap_core/tests/test_cli_packaging.py packages/gitmap_core/tests/test_doctor_command.py -q
- PYTHONPATH=packages:apps/cli/gitmap /Users/tr-mini/Projects/git-map/.venv/bin/pytest packages/gitmap_core/tests/test_remote.py -q
- PYTHONPATH=packages:apps/cli/gitmap /Users/tr-mini/Projects/git-map/.venv/bin/pytest packages/gitmap_core/tests/test_diff.py packages/gitmap_core/tests/test_cli_error_messages.py -q
- PYTHONPATH=packages:apps/cli/gitmap /Users/tr-mini/Projects/git-map/.venv/bin/pytest -q
- /Users/tr-mini/Projects/git-map/.venv/bin/python -m mkdocs build --strict
- git diff --check
- rg stale-command and public-safety scans

No merge, deploy, release, install, account change, paid action, outreach, or secret handling.