### PR TITLE
Fix CLI help example block rendering

### DIFF
--- a/apps/cli/gitmap/commands/clone.py
+++ b/apps/cli/gitmap/commands/clone.py
@@ -69,6 +69,8 @@ def clone(
     The map JSON is fetched from Portal and stored as the initial commit.
 
     Examples:
+
+    \b
         gitmap clone abc123def456
         gitmap clone abc123def456 --directory my-project
         gitmap clone abc123def456 --url https://portal.example.com

--- a/apps/cli/gitmap/commands/diff.py
+++ b/apps/cli/gitmap/commands/diff.py
@@ -256,6 +256,8 @@ def diff(
     commits directly — the staging area is not involved.
 
     Examples:
+
+    \b
         gitmap diff                               # Index vs HEAD
         gitmap diff main                          # Index vs main
         gitmap diff abc123                        # Index vs commit abc123

--- a/apps/cli/gitmap/commands/pull.py
+++ b/apps/cli/gitmap/commands/pull.py
@@ -70,6 +70,8 @@ def pull(
     then save with 'gitmap commit'.
 
     Examples:
+
+    \b
         gitmap pull
         gitmap pull --branch main
         gitmap pull --url https://portal.example.com

--- a/packages/gitmap_core/tests/test_cli_registration.py
+++ b/packages/gitmap_core/tests/test_cli_registration.py
@@ -213,6 +213,56 @@ class TestCommandRegistration:
         assert not missing, f"Documented gitmap diff options missing from CLI help: {missing}"
 
     @pytest.mark.parametrize(
+        ("command", "examples"),
+        [
+            (
+                "clone",
+                [
+                    "gitmap clone abc123def456",
+                    "gitmap clone abc123def456 --directory my-project",
+                    "gitmap clone abc123def456 --url https://portal.example.com",
+                ],
+            ),
+            (
+                "pull",
+                [
+                    "gitmap pull",
+                    "gitmap pull --branch main",
+                    "gitmap pull --url https://portal.example.com",
+                    'gitmap pull -r "Syncing production changes"',
+                ],
+            ),
+            (
+                "diff",
+                [
+                    "gitmap diff                               # Index vs HEAD",
+                    "gitmap diff main                          # Index vs main",
+                    "gitmap diff abc123                        # Index vs commit abc123",
+                    "gitmap diff main feature/new-layer        # Branch vs branch",
+                    "gitmap diff main feature --format visual  # Visual table view",
+                    "gitmap diff main feature --format json    # Machine-readable JSON",
+                    "gitmap diff abc123 def456                 # Commit vs commit",
+                ],
+            ),
+        ],
+    )
+    def test_first_user_command_examples_render_on_separate_lines(
+        self,
+        runner: CliRunner,
+        command: str,
+        examples: list[str],
+    ) -> None:
+        """First-user command help examples should remain readable command blocks."""
+        result = runner.invoke(cli, [command, "--help"], terminal_width=100)
+        assert result.exit_code == 0, f"{command} --help failed:\n{result.output}"
+
+        for example in examples:
+            assert f"  {example}" in result.output
+
+        examples_block = result.output.split("Examples:", maxsplit=1)[1].split("Options:", maxsplit=1)[0]
+        assert " ".join(examples) not in examples_block
+
+    @pytest.mark.parametrize(
         ("mistyped", "expected"),
         [
             ("statsu", "status"),


### PR DESCRIPTION
## Summary
- Preserve rendered line breaks for `gitmap clone`, `gitmap pull`, and `gitmap diff` help examples using Click's raw paragraph marker.
- Add regression coverage that invokes the rendered help for all three first-user commands and checks each example remains on its own line.

## Verification
- `.venv/bin/gitmap clone --help`
- `.venv/bin/gitmap pull --help`
- `.venv/bin/gitmap diff --help`
- `PYTHONPATH=/Users/tr-mini/Projects/git-map/packages:/Users/tr-mini/Projects/git-map/apps/cli/gitmap .venv/bin/python -m pytest packages/gitmap_core/tests/test_cli_registration.py -q` (17 passed)
- `PYTHONPATH=/Users/tr-mini/Projects/git-map/packages:/Users/tr-mini/Projects/git-map/apps/cli/gitmap .venv/bin/python -m pytest packages/gitmap_core/tests/test_cli_registration.py packages/gitmap_core/tests/test_cli_packaging.py packages/gitmap_core/tests/test_release_checks.py -q` (31 passed)
- `PYTHONPATH=/Users/tr-mini/Projects/git-map/packages:/Users/tr-mini/Projects/git-map/apps/cli/gitmap .venv/bin/python -m pytest packages/gitmap_core/tests/test_remote.py -q` (105 passed)
- `mkdocs build --strict` (passed with existing MkDocs Material warning)
- `git diff --check`
- touched-diff exposure scan

Fixes JIG-518.