### PR TITLE
docs: refresh validation proof count

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-785%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-791%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ pip install click rich
 pytest packages/gitmap_core/tests -v
 ```
 
-All 785+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 791+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -35,7 +35,7 @@ All 785+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 785+ tests live here
+│       └── tests/          # 791+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 785 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 791 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -210,7 +210,7 @@ The May 13, 2026 development checkout reports:
 
 - Version: `gitmap, version 0.7.0`.
 - Python support: `>=3.11,<3.15` in package metadata.
-- Core tests collected: 785 under `packages/gitmap_core/tests`.
+- Core tests collected: 791 under `packages/gitmap_core/tests`.
 - Integration tests collected: 66 across `integrations/openclaw/tests/test_tools.py` and `integrations/arcgis_pro/test_toolbox.py`.
 - Public docs: README, MkDocs command pages, quickstart, Portal guide, roadmap, and marketing demo script.
 - Recent git history: May 2026 work focused on first-user safety, demo placeholders, roadmap/adoption tracks, path normalization, and CLI/doc polish.
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 785 collected core tests and 66 collected integration tests.
+- Updated validation evidence to 791 collected core tests and 66 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.6.0+ with 785+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 791+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -95,7 +95,7 @@ When you `gitmap merge`, it performs a 3-way merge (base → source → target) 
 
 ---
 
-## What v0.6.0 Includes
+## What v0.7.0 Includes
 
 After 6 months of iteration, GitMap now has:
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **785+ tests** running in CI
+- **791+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 785+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 791+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -81,7 +81,7 @@ Before posting anywhere, nail the first-impression UX:
 ### GitHub hygiene
 - **Issues:** Create 5–10 "good first issue" items for contributors
 - **Discussions:** Enable GitHub Discussions for Q&A
-- **Releases:** Tag v0.6.0 properly with release notes pulled from CHANGELOG
+- **Releases:** Tag v0.7.0 properly with release notes pulled from CHANGELOG
 - **Stars goal:** 100 stars = meaningful social proof, 500+ = credibility with enterprise
 
 ### Content cadence
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.6.0+ with 785+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 791+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -2,7 +2,7 @@
 
 ## Title Options (pick one)
 1. **I got tired of "who changed the basemap?" and built Git for ArcGIS web maps [OC]**
-2. **GitMap v0.6.0 — open-source version control for ArcGIS Online/Enterprise web maps**
+2. **GitMap v0.7.0 public alpha — open-source version control for ArcGIS Online/Enterprise web maps**
 3. **Branch, commit, diff, and merge ArcGIS web maps like Git — open source tool I built**
 
 ---
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.6.0+, 785+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 791+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.6.0+ with 785+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 791+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 import importlib.util
+import os
+import re
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -56,6 +60,46 @@ def test_release_metadata_requires_existing_readmes_and_typed_markers() -> None:
     release_checks._validate_package_metadata(release_checks.ROOT_PYPROJECT)
     release_checks._validate_package_metadata(release_checks.CORE_PYPROJECT)
     release_checks._validate_package_metadata(release_checks.CLI_PYPROJECT)
+
+
+def test_public_validation_evidence_matches_collected_core_tests() -> None:
+    """Public proof claims should stay in sync with pytest collection."""
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join([str(REPO_ROOT / "packages"), str(REPO_ROOT)]),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "packages/gitmap_core/tests",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+    match = re.search(r"(\d+) tests collected", result.stdout)
+    assert match, result.stdout
+    collected_count = int(match.group(1))
+
+    public_claims = {
+        "README.md": f"tests-{collected_count}%2B",
+        "docs/contributing.md": f"{collected_count}+ tests",
+        "docs/technical-paper.md": f"{collected_count} collected core tests",
+        "marketing/blog-post.md": f"{collected_count}+ tests",
+        "marketing/launch-strategy.md": f"{collected_count}+ tests",
+        "marketing/reddit-rgis-post.md": f"{collected_count}+ tests",
+    }
+    for relative_path, expected_text in public_claims.items():
+        text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert expected_text in text, f"{relative_path} missing {expected_text!r}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- refresh public validation proof claims from 785+ to 791+ core tests
- update launch/blog/reddit draft copy from v0.6.0+ to v0.7.0 public alpha
- add a release-check regression that compares public proof claims to pytest collection

## Verification
- `pytest packages/gitmap_core/tests/test_release_checks.py -q`
- `pytest packages/gitmap_core/tests/test_cli_registration.py packages/gitmap_core/tests/test_release_checks.py -q`
- `pytest --collect-only -q packages/gitmap_core/tests` -> 791 tests collected
- `pytest --collect-only -q integrations/openclaw/tests/test_tools.py integrations/arcgis_pro/test_toolbox.py` -> 66 tests collected
- `mkdocs build --strict` (passes with existing MkDocs Material warning)
- `git diff --check`