### PR TITLE
docs: add doctor first-user preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-792%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-793%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 
@@ -24,12 +24,14 @@ Switched to branch feature/new-basemap
 $ gitmap pull
 Pulled latest web map JSON from Portal
 
-$ gitmap diff main feature/new-basemap --format visual
+$ gitmap diff --format visual
 ~ operationalLayers[2].visibility: false -> true
 + operationalLayers[5]: "Hydrants"
 
 $ gitmap commit -m "Add hydrants layer and enable parcels"
 [feature/new-basemap 8f2a1d9] Add hydrants layer and enable parcels
+
+$ gitmap diff main feature/new-basemap --format visual
 
 $ gitmap checkout main
 $ gitmap merge feature/new-basemap
@@ -189,19 +191,26 @@ Review the branch against `main`:
 
 ```bash
 gitmap status
-gitmap diff main feature/hydrology-update --format visual
+gitmap diff --format visual
 ```
 
 For a shareable stakeholder review artifact:
 
 ```bash
-gitmap diff main feature/hydrology-update --format html --output hydrology-review.html
+gitmap diff --format html --output hydrology-review.html
 ```
 
 ### 6. Commit the approved change
 
 ```bash
 gitmap commit -m "Update hydrology layers"
+```
+
+After committing the feature branch, you can compare the saved branch tip against
+`main`:
+
+```bash
+gitmap diff main feature/hydrology-update --format visual
 ```
 
 Optional rationale text can be saved with the commit:
@@ -233,8 +242,9 @@ gitmap checkout feature/try-imagery-basemap
 
 # make the map change in ArcGIS, then sync it locally
 gitmap pull
-gitmap diff main feature/try-imagery-basemap --format visual
+gitmap diff --format visual
 gitmap commit -m "Try imagery basemap"
+gitmap diff main feature/try-imagery-basemap --format visual
 ```
 
 ### Review changes before release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-791%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-792%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 
@@ -81,6 +81,7 @@ This installs the `gitmap` console command. Verify the CLI is available:
 ```bash
 gitmap --version
 gitmap --help
+gitmap doctor
 ```
 
 ### Install from source
@@ -148,6 +149,15 @@ cd flood-risk-map
 ```
 
 The clone command creates a local GitMap repository containing the web map JSON, GitMap metadata, and an initial commit for the current Portal state. It does not modify the Portal item.
+
+If install, package, credential, or current-directory checks are unclear before cloning, run:
+
+```bash
+gitmap doctor
+gitmap doctor --portal
+```
+
+`gitmap doctor` checks the local environment without writing to Portal. The `--portal` option attempts a connectivity check against the configured ArcGIS organization.
 
 ### 3. Check the starting state
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ pip install click rich
 pytest packages/gitmap_core/tests -v
 ```
 
-All 791+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 792+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -35,7 +35,7 @@ All 791+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 791+ tests live here
+│       └── tests/          # 792+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ pip install click rich
 pytest packages/gitmap_core/tests -v
 ```
 
-All 792+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 793+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -35,7 +35,7 @@ All 792+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 792+ tests live here
+│       └── tests/          # 793+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -21,6 +21,7 @@ Make sure you have gitmap installed:
 ```bash
 pip install gitmap-cli
 gitmap --version
+gitmap doctor
 ```
 
 You also need an ArcGIS Online or Portal web map item ID. Open the web map item page and copy the `id` value from the URL, such as `...?id=abc123def456`.
@@ -41,6 +42,14 @@ Or copy the example env file and edit it:
 cp configs/env.example .env
 # edit .env with your credentials
 ```
+
+Check the Portal connection before cloning:
+
+```bash
+gitmap doctor --portal
+```
+
+`gitmap doctor` is read-only. It verifies the local environment, credential variables, current directory, and, with `--portal`, whether GitMap can connect to the configured ArcGIS organization.
 
 ## 2. Clone an Existing Map
 
@@ -132,7 +141,7 @@ gitmap push
 
 ## First-Run Troubleshooting
 
-- Missing credentials: set `ARCGIS_USERNAME`, `ARCGIS_PASSWORD`, and `PORTAL_URL`, or create a local `.env` file.
+- Missing credentials: set `ARCGIS_USERNAME`, `ARCGIS_PASSWORD`, and `PORTAL_URL`, or create a local `.env` file, then run `gitmap doctor --portal`.
 - Missing command: install with `pip install gitmap-cli`, then run `gitmap --version`.
 - Wrong item ID: copy the web map item ID from the ArcGIS item page URL, not the map title or layer ID.
 - Wrong directory: run GitMap commands from the folder created by `gitmap clone`.

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 791 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 792 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -210,7 +210,7 @@ The May 13, 2026 development checkout reports:
 
 - Version: `gitmap, version 0.7.0`.
 - Python support: `>=3.11,<3.15` in package metadata.
-- Core tests collected: 791 under `packages/gitmap_core/tests`.
+- Core tests collected: 792 under `packages/gitmap_core/tests`.
 - Integration tests collected: 66 across `integrations/openclaw/tests/test_tools.py` and `integrations/arcgis_pro/test_toolbox.py`.
 - Public docs: README, MkDocs command pages, quickstart, Portal guide, roadmap, and marketing demo script.
 - Recent git history: May 2026 work focused on first-user safety, demo placeholders, roadmap/adoption tracks, path normalization, and CLI/doc polish.
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 791 collected core tests and 66 collected integration tests.
+- Updated validation evidence to 792 collected core tests and 66 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 792 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 793 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -210,7 +210,7 @@ The May 13, 2026 development checkout reports:
 
 - Version: `gitmap, version 0.7.0`.
 - Python support: `>=3.11,<3.15` in package metadata.
-- Core tests collected: 792 under `packages/gitmap_core/tests`.
+- Core tests collected: 793 under `packages/gitmap_core/tests`.
 - Integration tests collected: 66 across `integrations/openclaw/tests/test_tools.py` and `integrations/arcgis_pro/test_toolbox.py`.
 - Public docs: README, MkDocs command pages, quickstart, Portal guide, roadmap, and marketing demo script.
 - Recent git history: May 2026 work focused on first-user safety, demo placeholders, roadmap/adoption tracks, path normalization, and CLI/doc polish.
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 792 collected core tests and 66 collected integration tests.
+- Updated validation evidence to 793 collected core tests and 66 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/docs/validation/first-user-test.md
+++ b/docs/validation/first-user-test.md
@@ -43,9 +43,11 @@ gitmap push
 2. Confirm the tester can sign in to the ArcGIS organization in a browser.
 3. Confirm the tester can safely modify the disposable web map.
 4. Create a clean terminal session with no prior GitMap repository state.
-5. Have the tester open the GitMap README and quickstart, but do not coach the
+5. Have the tester run `gitmap doctor` after install and `gitmap doctor --portal`
+   after credentials are configured.
+6. Have the tester open the GitMap README and quickstart, but do not coach the
    command sequence unless they are blocked.
-6. Start a timer when the tester begins reading the install instructions.
+7. Start a timer when the tester begins reading the install instructions.
 
 ## Observer Checklist
 
@@ -54,7 +56,9 @@ Record short notes for each step:
 | Step | Pass criteria | Notes to collect |
 |------|---------------|------------------|
 | Install | `gitmap --help` works | Python version, shell, install command, error text |
+| Doctor | `gitmap doctor` completes | Missing package, env var, or current-directory warning |
 | Credentials | GitMap connects to Portal | Env var or `.env` path used, unclear field names |
+| Portal preflight | `gitmap doctor --portal` succeeds or gives a clear blocker | Auth, URL, permission, or package blocker |
 | Item ID | Tester finds the web map item ID | Where they looked, any URL confusion |
 | Clone | Local repo is created | Output clarity, directory confusion |
 | Branch | Feature branch is active | Whether branch naming made sense |
@@ -99,6 +103,8 @@ Stop the test and preserve notes if:
 - ArcGIS target: disposable test web map
 - Completed core loop: yes/no
 - Time to `gitmap --help`:
+- Time to `gitmap doctor`:
+- `gitmap doctor --portal` result:
 - Time to clone:
 - Time to first diff:
 - Pushed to test item knowingly: yes/no/not attempted

--- a/docs/validation/first-user-test.md
+++ b/docs/validation/first-user-test.md
@@ -17,8 +17,9 @@ gitmap branch feature/validation-change
 gitmap checkout feature/validation-change
 gitmap pull
 gitmap status
-gitmap diff main feature/validation-change --format visual
+gitmap diff --format visual
 gitmap commit -m "Validate GitMap workflow"
+gitmap diff main feature/validation-change --format visual
 gitmap checkout main
 gitmap merge feature/validation-change
 gitmap push

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 791+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 792+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **791+ tests** running in CI
+- **792+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 791+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 792+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 792+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 793+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **792+ tests** running in CI
+- **793+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 792+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 793+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 791+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 792+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 792+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 793+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 791+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 792+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 791+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 792+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 792+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 793+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 792+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 793+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/packages/gitmap_core/tests/test_doctor_command.py
+++ b/packages/gitmap_core/tests/test_doctor_command.py
@@ -104,3 +104,18 @@ def test_first_user_docs_include_doctor_preflight() -> None:
         text = doc_path.read_text(encoding="utf-8")
         assert "gitmap doctor" in text, f"{doc_path} should mention gitmap doctor"
         assert "gitmap doctor --portal" in text, f"{doc_path} should mention the Portal preflight"
+
+
+def test_first_user_validation_diff_order_matches_staged_workflow() -> None:
+    """The first-user flow should diff staged changes before branch comparison."""
+    repo_root = Path(__file__).resolve().parents[3]
+    doc_path = repo_root / "docs/validation/first-user-test.md"
+    text = doc_path.read_text(encoding="utf-8")
+
+    pull_index = text.index("gitmap pull")
+    status_index = text.index("gitmap status")
+    staged_diff_index = text.index("gitmap diff --format visual")
+    commit_index = text.index('gitmap commit -m "Validate GitMap workflow"')
+    branch_diff_index = text.index("gitmap diff main feature/validation-change --format visual")
+
+    assert pull_index < status_index < staged_diff_index < commit_index < branch_diff_index

--- a/packages/gitmap_core/tests/test_doctor_command.py
+++ b/packages/gitmap_core/tests/test_doctor_command.py
@@ -89,3 +89,18 @@ class TestDoctorCommand:
         """doctor must appear in top-level --help output."""
         result = runner.invoke(cli, ["--help"])
         assert "doctor" in result.output, f"'doctor' not found in CLI help:\n{result.output}"
+
+
+def test_first_user_docs_include_doctor_preflight() -> None:
+    """First-user docs should keep the diagnostic preflight visible."""
+    repo_root = Path(__file__).resolve().parents[3]
+    docs_to_check = [
+        repo_root / "README.md",
+        repo_root / "docs/getting-started/quickstart.md",
+        repo_root / "docs/validation/first-user-test.md",
+    ]
+
+    for doc_path in docs_to_check:
+        text = doc_path.read_text(encoding="utf-8")
+        assert "gitmap doctor" in text, f"{doc_path} should mention gitmap doctor"
+        assert "gitmap doctor --portal" in text, f"{doc_path} should mention the Portal preflight"


### PR DESCRIPTION
## Summary
- add gitmap doctor to README and quickstart first-run preflight guidance
- add doctor/portal-preflight checkpoints to the first-user validation protocol
- guard the onboarding docs with a focused regression and refresh public test-count claims to 792+

## Validation
- PYTHONPATH=/Users/tr-mini/Desktop/tr-jig/artifacts/gitmap-jig584-origin-main/packages:/Users/tr-mini/Desktop/tr-jig/artifacts/gitmap-jig584-origin-main /opt/homebrew/bin/python3 -m pytest packages/gitmap_core/tests/test_doctor_command.py packages/gitmap_core/tests/test_release_checks.py -q
- PYTHONPATH=/Users/tr-mini/Desktop/tr-jig/artifacts/gitmap-jig584-origin-main/packages:/Users/tr-mini/Desktop/tr-jig/artifacts/gitmap-jig584-origin-main /opt/homebrew/bin/python3 -m pytest packages/gitmap_core/tests -q
- /opt/homebrew/bin/python3 scripts/release_checks.py
- /opt/homebrew/bin/python3 -m ruff check packages/gitmap_core/tests/test_doctor_command.py
- /opt/homebrew/bin/python3 -m mkdocs build --strict --site-dir /tmp/gitmap-jig584-mkdocs
- git diff --check

## Notes
- Raw git push was unavailable in the OpenClaw cron shell, so the branch was published via the repo's gh-safe Git data API path.
- No Portal calls, deploy, merge, release, install, outreach, or public posting were performed.