### PR TITLE
Fail closed when Portal preflight cannot run

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-793%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-794%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-794%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-796%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 

--- a/apps/cli/gitmap/commands/doctor.py
+++ b/apps/cli/gitmap/commands/doctor.py
@@ -88,6 +88,8 @@ def doctor(check_portal: bool, show_fixes: bool) -> None:
     and optionally tests Portal connectivity.
 
     Examples:
+
+    \b
         gitmap doctor
         gitmap doctor --portal
         gitmap doctor --fix

--- a/apps/cli/gitmap/commands/doctor.py
+++ b/apps/cli/gitmap/commands/doctor.py
@@ -188,6 +188,8 @@ def doctor(check_portal: bool, show_fixes: bool) -> None:
         if not _pkg_installed("arcgis"):
             console.print("  [yellow]⊘[/yellow] arcgis package not installed — cannot test connectivity")
             console.print("  [dim]Install with: pip install arcgis[/dim]")
+            issues.append("Portal connectivity check could not run because the arcgis package is not installed")
+            all_ok = False
         else:
             try:
                 from gitmap_core.connection import get_connection

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ pip install click rich
 pytest packages/gitmap_core/tests -v
 ```
 
-All 794+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 796+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -35,7 +35,7 @@ All 794+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 794+ tests live here
+│       └── tests/          # 796+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ pip install click rich
 pytest packages/gitmap_core/tests -v
 ```
 
-All 793+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 794+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -35,7 +35,7 @@ All 793+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 793+ tests live here
+│       └── tests/          # 794+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 793 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 794 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -210,7 +210,7 @@ The May 13, 2026 development checkout reports:
 
 - Version: `gitmap, version 0.7.0`.
 - Python support: `>=3.11,<3.15` in package metadata.
-- Core tests collected: 793 under `packages/gitmap_core/tests`.
+- Core tests collected: 794 under `packages/gitmap_core/tests`.
 - Integration tests collected: 66 across `integrations/openclaw/tests/test_tools.py` and `integrations/arcgis_pro/test_toolbox.py`.
 - Public docs: README, MkDocs command pages, quickstart, Portal guide, roadmap, and marketing demo script.
 - Recent git history: May 2026 work focused on first-user safety, demo placeholders, roadmap/adoption tracks, path normalization, and CLI/doc polish.
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 793 collected core tests and 66 collected integration tests.
+- Updated validation evidence to 794 collected core tests and 66 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 794 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 796 collected core tests, 66 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -210,7 +210,7 @@ The May 13, 2026 development checkout reports:
 
 - Version: `gitmap, version 0.7.0`.
 - Python support: `>=3.11,<3.15` in package metadata.
-- Core tests collected: 794 under `packages/gitmap_core/tests`.
+- Core tests collected: 796 under `packages/gitmap_core/tests`.
 - Integration tests collected: 66 across `integrations/openclaw/tests/test_tools.py` and `integrations/arcgis_pro/test_toolbox.py`.
 - Public docs: README, MkDocs command pages, quickstart, Portal guide, roadmap, and marketing demo script.
 - Recent git history: May 2026 work focused on first-user safety, demo placeholders, roadmap/adoption tracks, path normalization, and CLI/doc polish.
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 794 collected core tests and 66 collected integration tests.
+- Updated validation evidence to 796 collected core tests and 66 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/docs/validation/first-user-test.md
+++ b/docs/validation/first-user-test.md
@@ -11,6 +11,8 @@ A first-time user can complete the core GitMap loop on a non-production ArcGIS
 web map:
 
 ```bash
+gitmap doctor
+gitmap doctor --portal
 gitmap clone <TEST_ITEM_ID> --directory gitmap-validation-map
 cd gitmap-validation-map
 gitmap branch feature/validation-change

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 794+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 796+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **794+ tests** running in CI
+- **796+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 794+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 796+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 793+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 794+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **793+ tests** running in CI
+- **794+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 793+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 794+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 793+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 794+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 794+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 796+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 794+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 796+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 794+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 796+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 793+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 794+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 793+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 794+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/packages/gitmap_core/compat.py
+++ b/packages/gitmap_core/compat.py
@@ -401,8 +401,5 @@ def get_item_data(item: Any) -> dict[str, Any] | None:
         return None
 
 
-# ---- Initialize on import -----------------------------------------------------------------------------------
-
-
-# Run compatibility check when module is imported
-validate_or_warn()
+# Compatibility checks are intentionally explicit. Importing gitmap_core.compat
+# must stay quiet so CLI help can render without Portal/ArcGIS diagnostics.

--- a/packages/gitmap_core/tests/test_doctor_command.py
+++ b/packages/gitmap_core/tests/test_doctor_command.py
@@ -16,6 +16,8 @@ Dependencies:
 
 from __future__ import annotations
 
+import os
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -58,6 +60,43 @@ class TestDoctorCommand:
         result = runner.invoke(cli, ["doctor", "--help"])
         assert result.exit_code == 0, f"doctor --help failed:\n{result.output}"
         assert "environment" in result.output.lower() or "check" in result.output.lower()
+        assert "ArcGIS compatibility" not in result.output
+
+    def test_doctor_help_examples_render_on_separate_lines(self, runner: CliRunner) -> None:
+        """doctor --help should keep examples readable for first users."""
+        result = runner.invoke(cli, ["doctor", "--help"], terminal_width=100)
+        assert result.exit_code == 0, f"doctor --help failed:\n{result.output}"
+
+        examples = [
+            "gitmap doctor",
+            "gitmap doctor --portal",
+            "gitmap doctor --fix",
+        ]
+        for example in examples:
+            assert f"  {example}" in result.output
+
+        examples_block = result.output.split("Examples:", maxsplit=1)[1].split("Options:", maxsplit=1)[0]
+        assert " ".join(examples) not in examples_block
+
+    def test_doctor_help_source_execution_is_warning_free(self) -> None:
+        """Direct source help should not emit ArcGIS compatibility warnings."""
+        repo_root = Path(__file__).resolve().parents[3]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = f"{repo_root / 'packages'}:{repo_root}"
+        result = subprocess.run(
+            [sys.executable, "-m", "apps.cli.gitmap.main", "doctor", "--help"],
+            cwd=repo_root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        combined_output = result.stdout + result.stderr
+
+        assert result.returncode == 0, combined_output
+        assert "Usage:" in combined_output
+        assert "ArcGIS compatibility" not in combined_output
+        assert not combined_output.lstrip().startswith("ArcGIS compatibility")
 
     def test_doctor_runs_in_empty_dir(self, runner: CliRunner, tmp_path) -> None:
         """doctor should complete without unhandled exceptions in a non-repo dir."""

--- a/packages/gitmap_core/tests/test_doctor_command.py
+++ b/packages/gitmap_core/tests/test_doctor_command.py
@@ -41,6 +41,7 @@ if "gitmap_cli" not in sys.modules:
 if str(_cli_dir) not in sys.path:
     sys.path.insert(0, str(_cli_dir))
 
+from gitmap_cli.commands import doctor as doctor_module  # noqa: E402
 from main import cli  # noqa: E402
 
 
@@ -90,6 +91,24 @@ class TestDoctorCommand:
         result = runner.invoke(cli, ["--help"])
         assert "doctor" in result.output, f"'doctor' not found in CLI help:\n{result.output}"
 
+    def test_doctor_portal_missing_arcgis_reports_issue(
+        self, runner: CliRunner, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """doctor --portal should fail clearly when Portal connectivity cannot be tested."""
+
+        def fake_pkg_installed(import_name: str) -> bool:
+            return import_name != "arcgis"
+
+        monkeypatch.setattr(doctor_module, "_pkg_installed", fake_pkg_installed)
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["doctor", "--portal"])
+
+        assert result.exit_code == 1
+        assert "arcgis package not installed" in result.output
+        assert "Portal connectivity check could not run" in result.output
+        assert "No issues found" not in result.output
+
 
 def test_first_user_docs_include_doctor_preflight() -> None:
     """First-user docs should keep the diagnostic preflight visible."""
@@ -104,6 +123,10 @@ def test_first_user_docs_include_doctor_preflight() -> None:
         text = doc_path.read_text(encoding="utf-8")
         assert "gitmap doctor" in text, f"{doc_path} should mention gitmap doctor"
         assert "gitmap doctor --portal" in text, f"{doc_path} should mention the Portal preflight"
+
+    validation_text = (repo_root / "docs/validation/first-user-test.md").read_text(encoding="utf-8")
+    assert validation_text.index("gitmap doctor") < validation_text.index("gitmap clone <TEST_ITEM_ID>")
+    assert validation_text.index("gitmap doctor --portal") < validation_text.index("gitmap clone <TEST_ITEM_ID>")
 
 
 def test_first_user_validation_diff_order_matches_staged_workflow() -> None:


### PR DESCRIPTION
## Summary
- make `gitmap doctor --portal` return a failing diagnostic when the `arcgis` package is unavailable and Portal connectivity cannot be tested
- put `gitmap doctor` and `gitmap doctor --portal` at the start of the first-user validation command path
- add regression coverage and refresh public proof-count claims to 794+ tests

## Verification
- `PYTHONPATH=/Users/tr-mini/Desktop/tr-jig/artifacts/gitmap-jig623-origin-main/packages:/Users/tr-mini/Desktop/tr-jig/artifacts/gitmap-jig623-origin-main /opt/homebrew/bin/python3 -m pytest packages/gitmap_core/tests -q` -> 794 passed
- `/opt/homebrew/bin/python3 -m ruff check apps/cli/gitmap/commands/doctor.py packages/gitmap_core/tests/test_doctor_command.py` -> passed
- `/opt/homebrew/bin/python3 scripts/release_checks.py` -> passed
- `/opt/homebrew/bin/python3 -m mkdocs build --strict --site-dir /tmp/gitmap-jig623-mkdocs` -> passed with existing MkDocs Material advisory
- `git diff --check` -> passed

## Notes
- No Portal calls, merge, deploy, release, package publish, install, public post, outreach, account/payment/DNS change, default-branch push, or real-secret handling.
