### PR TITLE
OpenClaw integration health smoke

### DIFF
--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,6 +1,6 @@
 # Git-Map OpenClaw Integration
 
-OpenClaw plugin for Git-Map version control. Provides 8 tools for managing ArcGIS web maps using Git-like operations.
+OpenClaw plugin for Git-Map version control. Provides 9 tools for managing ArcGIS web maps using Git-like operations.
 
 ## Prerequisites
 
@@ -47,6 +47,7 @@ OpenClaw plugin for Git-Map version control. Provides 8 tools for managing ArcGI
 
 | Tool | Description |
 |------|-------------|
+| `gitmap_health` | Check local GitMap/OpenClaw integration readiness without contacting Portal |
 | `gitmap_list` | List available web maps from ArcGIS Portal/AGOL |
 | `gitmap_status` | Show working tree status for a GitMap repository |
 | `gitmap_commit` | Commit the current map state |
@@ -93,6 +94,7 @@ Alternatively, pass credentials directly to tools as parameters.
 ## Troubleshooting
 
 - **Server not starting**: Check Python dependencies are installed and `GITMAP_ROOT` points at a valid GitMap checkout if you are not running from this repository
+- **Health check failing**: Run `curl http://localhost:7400/health` or call `gitmap_health`; both report the resolved GitMap root and local CLI/source-tree checks without contacting Portal
 - **Wrong repo path**: OpenClaw sends `repo_path`; the Python server normalizes it to the CLI wrapper `cwd` parameter
 - **Tools not working**: Ensure `PORTAL_URL` is set and credentials are valid
 - **Plugin not loading**: Run `openclaw plugins list` to verify installation

--- a/integrations/openclaw/index.ts
+++ b/integrations/openclaw/index.ts
@@ -30,6 +30,21 @@ export default function (api: any) {
 
   api.registerTool(
     {
+      name: "gitmap_health",
+      description: "Check local GitMap/OpenClaw integration readiness without contacting Portal.",
+      parameters: {
+        type: "object",
+        properties: {},
+      },
+      async execute() {
+        return callTool(serverUrl, "gitmap_health", {});
+      },
+    },
+    { optional: true },
+  );
+
+  api.registerTool(
+    {
       name: "gitmap_list",
       description: "List available web maps from ArcGIS Portal/AGOL.",
       parameters: {

--- a/integrations/openclaw/server.py
+++ b/integrations/openclaw/server.py
@@ -30,6 +30,11 @@ PORT = 7400
 # ---- Tool registry -------------------------------------------------------------------
 
 TOOL_REGISTRY = {
+    "gitmap_health": {
+        "fn": gitmap_tools.gitmap_health,
+        "description": "Check local GitMap/OpenClaw integration readiness without contacting Portal",
+        "params": {},
+    },
     "gitmap_list": {
         "fn": gitmap_tools.gitmap_list,
         "description": "List available web maps from Portal or ArcGIS Online",
@@ -187,7 +192,11 @@ class GitMapHandler(BaseHTTPRequestHandler):
         path = urllib.parse.urlparse(self.path).path.rstrip("/")
 
         if path == "/health":
-            self.send_json({"ok": True, "service": "gitmap-skill", "port": PORT})
+            self.send_json({
+                "service": "gitmap-skill",
+                "port": PORT,
+                **gitmap_tools._health(),
+            })
 
         elif path == "/tools":
             tool_list = [

--- a/integrations/openclaw/tests/test_tools.py
+++ b/integrations/openclaw/tests/test_tools.py
@@ -18,6 +18,8 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 TOOLS_PATH = Path(__file__).resolve().parents[1] / "tools.py"
 SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
 TOOLS_SPEC = importlib.util.spec_from_file_location("gitmap_openclaw_tools", TOOLS_PATH)
@@ -39,6 +41,22 @@ class TestGitmapRoot:
         repo_root = Path(__file__).resolve().parents[3]
 
         assert repo_root == gitmap_tools.GITMAP_CLI_DIR
+
+    def test_missing_root_requires_explicit_config(self, tmp_path: Path) -> None:
+        """Root discovery fails closed instead of assuming a Desktop checkout."""
+        with patch.dict("os.environ", {"GITMAP_ROOT": str(tmp_path)}), \
+             pytest.raises(RuntimeError, match="GITMAP_ROOT"):
+            gitmap_tools._default_gitmap_root()
+
+    def test_health_reports_local_source_tree(self) -> None:
+        """Health reports non-secret local integration readiness."""
+        health = gitmap_tools.gitmap_health()
+
+        assert health["ok"] is True
+        assert health["checks"]["root_exists"] is True
+        assert health["checks"]["core_package_exists"] is True
+        assert health["checks"]["cli_package_exists"] is True
+        assert "cli_command" in health
 
 
 class TestServerParameterNormalization:
@@ -70,6 +88,10 @@ class TestServerParameterNormalization:
         )
 
         assert params == {"cwd": "/tmp/map-repo", "branch": "main"}
+
+    def test_health_tool_is_registered(self) -> None:
+        """Server exposes a health tool for OpenClaw-level smoke checks."""
+        assert "gitmap_health" in gitmap_server.TOOL_REGISTRY
 
 
 # ---- _find_gitmap() ------------------------------------------------------------------

--- a/integrations/openclaw/tools.py
+++ b/integrations/openclaw/tools.py
@@ -39,13 +39,18 @@ def _default_gitmap_root() -> Path:
     """
     configured_root = os.environ.get("GITMAP_ROOT")
     if configured_root:
-        return Path(configured_root).expanduser().resolve()
+        root = Path(configured_root).expanduser().resolve()
+        if (root / "apps" / "cli" / "gitmap").exists() and (root / "packages" / "gitmap_core").exists():
+            return root
+        raise RuntimeError(f"GITMAP_ROOT does not point to a GitMap checkout: {root}")
 
     for candidate in Path(__file__).resolve().parents:
         if (candidate / "apps" / "cli" / "gitmap").exists() and (candidate / "packages" / "gitmap_core").exists():
             return candidate
 
-    return Path.home() / "Desktop" / "Git-Map"
+    raise RuntimeError(
+        "Unable to locate GitMap source tree. Set GITMAP_ROOT to the GitMap checkout path."
+    )
 
 
 GITMAP_CLI_DIR = _default_gitmap_root()
@@ -76,6 +81,33 @@ def _find_gitmap() -> list[str]:
 
     # Last resort: try the module directly
     return [python, "-m", "gitmap_cli.main"]
+
+
+def _health() -> dict:
+    """
+    Return non-secret local readiness details for the OpenClaw integration.
+
+    This intentionally avoids Portal connectivity so health checks stay safe in
+    unauthenticated and CI environments.
+    """
+    root = GITMAP_CLI_DIR
+    core_dir = root / "packages" / "gitmap_core"
+    cli_dir = root / "apps" / "cli" / "gitmap"
+    cli_command = _find_gitmap()
+
+    checks = {
+        "root_exists": root.exists(),
+        "core_package_exists": core_dir.exists(),
+        "cli_package_exists": cli_dir.exists(),
+        "cli_entry_exists": (cli_dir / "main.py").exists(),
+    }
+
+    return {
+        "ok": all(checks.values()),
+        "root": str(root),
+        "cli_command": cli_command,
+        "checks": checks,
+    }
 
 
 def _run(
@@ -184,6 +216,28 @@ def _portal_flags(
 
 
 # ---- Tools ---------------------------------------------------------------------------
+
+def gitmap_health() -> dict:
+    """
+    Check local GitMap/OpenClaw integration readiness without contacting Portal.
+
+    Returns:
+        dict: ok, root, cli command, and local source-tree checks.
+    """
+    health = _health()
+    output = (
+        "GitMap integration ready"
+        if health["ok"]
+        else "GitMap integration is not ready"
+    )
+    return {
+        "ok": health["ok"],
+        "returncode": 0 if health["ok"] else -1,
+        "stdout": output,
+        "stderr": "" if health["ok"] else output,
+        "output": output,
+        **health,
+    }
 
 def gitmap_list(
         query: Optional[str] = None,


### PR DESCRIPTION
## Summary
- add a non-Portal `gitmap_health` OpenClaw tool and richer `/health` payload
- fail closed when `GITMAP_ROOT` points outside a GitMap checkout instead of assuming a Desktop path
- document the health smoke and cover root/parameter/registry behavior in tests

## Verification
- `/opt/homebrew/bin/python3 -m pytest integrations/openclaw/tests/test_tools.py -q` -> 40 passed
- `/opt/homebrew/bin/python3 -m py_compile integrations/openclaw/tools.py integrations/openclaw/server.py integrations/openclaw/tests/test_tools.py`
- `git diff --check`
- local server smoke: `/health`, `/tools`, and `POST /tools/gitmap_health` all returned ok with root checks true

## Guardrails
No Portal write, install, deploy, merge, public post, outreach, account change, paid action, or secret handling.
