### PR TITLE
Fix doctor --portal credential preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-797%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-798%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 

--- a/apps/cli/gitmap/commands/doctor.py
+++ b/apps/cli/gitmap/commands/doctor.py
@@ -50,6 +50,9 @@ ENV_VARS: list[tuple[str, str, bool]] = [
     ("ARCGIS_PASSWORD", "Portal password (or use keyring)", False),
 ]
 
+PORTAL_USERNAME_VARS = ("PORTAL_USER", "ARCGIS_USERNAME")
+PORTAL_PASSWORD_VARS = ("PORTAL_PASSWORD", "ARCGIS_PASSWORD")
+
 
 def _check(ok: bool) -> str:
     return "[green]✓[/green]" if ok else "[red]✗[/red]"
@@ -60,7 +63,18 @@ def _warn(value: bool) -> str:
 
 
 def _pkg_installed(import_name: str) -> bool:
-    return importlib.util.find_spec(import_name) is not None
+    try:
+        return importlib.util.find_spec(import_name) is not None
+    except ValueError:
+        return False
+
+
+def _first_set_env(var_names: tuple[str, ...]) -> str | None:
+    for var_name in var_names:
+        value = os.environ.get(var_name)
+        if value:
+            return value
+    return None
 
 
 # ---- Doctor Command -----------------------------------------------------------------------------------------
@@ -184,23 +198,37 @@ def doctor(check_portal: bool, show_fixes: bool) -> None:
     if check_portal:
         console.print("[bold dim]─── Portal Connectivity ───[/bold dim]")
         portal_url = os.environ.get("PORTAL_URL", "https://www.arcgis.com")
-        username = os.environ.get("ARCGIS_USERNAME", "")
-        password = os.environ.get("ARCGIS_PASSWORD", "")
+        username = _first_set_env(PORTAL_USERNAME_VARS)
+        password = _first_set_env(PORTAL_PASSWORD_VARS)
 
-        if not _pkg_installed("arcgis"):
+        if not username or not password:
+            missing = []
+            if not username:
+                missing.append("ARCGIS_USERNAME or PORTAL_USER")
+            if not password:
+                missing.append("ARCGIS_PASSWORD or PORTAL_PASSWORD")
+            missing_text = "; ".join(missing)
+            console.print(f"  {_check(False)} Missing Portal credentials: {missing_text}")
+            console.print("  [dim]Set credentials before using doctor --portal as a credential preflight.[/dim]")
+            issues.append(f"Portal credential preflight missing credentials: {missing_text}")
+            all_ok = False
+            console.print()
+            check_portal = False
+
+        if check_portal and not _pkg_installed("arcgis"):
             console.print("  [yellow]⊘[/yellow] arcgis package not installed — cannot test connectivity")
             console.print("  [dim]Install with: pip install arcgis[/dim]")
             issues.append("Portal connectivity check could not run because the arcgis package is not installed")
             all_ok = False
-        else:
+        elif check_portal:
             try:
                 from gitmap_core.connection import get_connection
 
                 console.print(f"  [dim]Connecting to {portal_url} ...[/dim]")
                 conn = get_connection(
                     url=portal_url,
-                    username=username or None,
-                    password=password or None,
+                    username=username,
+                    password=password,
                 )
                 if conn.username:
                     console.print(f"  {_check(True)} Connected as [cyan]{conn.username}[/cyan]")

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ pip install click rich
 pytest packages/gitmap_core/tests -v
 ```
 
-All 797+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 798+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -35,7 +35,7 @@ All 797+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 797+ tests live here
+│       └── tests/          # 798+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 797 collected core tests, 69 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 798 collected core tests, 69 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -210,7 +210,7 @@ The May 13, 2026 development checkout reports:
 
 - Version: `gitmap, version 0.7.0`.
 - Python support: `>=3.11,<3.15` in package metadata.
-- Core tests collected: 797 under `packages/gitmap_core/tests`.
+- Core tests collected: 798 under `packages/gitmap_core/tests`.
 - Integration tests collected: 69 across `integrations/openclaw/tests/test_tools.py` (40) and `integrations/arcgis_pro/test_toolbox.py` (29).
 - Public docs: README, MkDocs command pages, quickstart, Portal guide, roadmap, and marketing demo script.
 - Recent git history: May 2026 work focused on first-user safety, demo placeholders, roadmap/adoption tracks, path normalization, and CLI/doc polish.
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 797 collected core tests and 69 collected integration tests.
+- Updated validation evidence to 798 collected core tests and 69 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 797+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 798+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **797+ tests** running in CI
+- **798+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 797+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 798+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 797+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 798+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 797+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 798+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 797+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 798+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/packages/gitmap_core/tests/test_doctor_command.py
+++ b/packages/gitmap_core/tests/test_doctor_command.py
@@ -125,6 +125,24 @@ class TestDoctorCommand:
             result = runner.invoke(cli, ["doctor", "--fix"])
         assert result.exit_code in (0, 1)
 
+    def test_doctor_portal_requires_credentials(
+        self,
+        runner: CliRunner,
+        tmp_path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """doctor --portal should not treat anonymous Portal access as credential success."""
+        for var_name in ("PORTAL_USER", "PORTAL_PASSWORD", "ARCGIS_USERNAME", "ARCGIS_PASSWORD"):
+            monkeypatch.delenv(var_name, raising=False)
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            result = runner.invoke(cli, ["doctor", "--portal"])
+
+        assert result.exit_code == 1
+        assert "Missing Portal credentials" in result.output
+        assert "credential preflight" in result.output
+        assert "Connected (anonymous)" not in result.output
+
     def test_doctor_registered_in_help(self, runner: CliRunner) -> None:
         """doctor must appear in top-level --help output."""
         result = runner.invoke(cli, ["--help"])
@@ -139,6 +157,8 @@ class TestDoctorCommand:
             return import_name != "arcgis"
 
         monkeypatch.setattr(doctor_module, "_pkg_installed", fake_pkg_installed)
+        monkeypatch.setenv("ARCGIS_USERNAME", "test_user")
+        monkeypatch.setenv("ARCGIS_PASSWORD", "test_password")
 
         with runner.isolated_filesystem(temp_dir=tmp_path):
             result = runner.invoke(cli, ["doctor", "--portal"])


### PR DESCRIPTION
## Summary
- make `gitmap doctor --portal` fail fast when no Portal credential env vars are configured
- avoid falling through to anonymous ArcGIS Online as a credential-preflight success
- add a regression that verifies the missing-credentials path does not print anonymous success
- update public validation evidence from 797+ to 798+ collected core tests after adding the regression

## Verification
- `env -u PORTAL_URL -u PORTAL_USER -u PORTAL_PASSWORD -u ARCGIS_USERNAME -u ARCGIS_PASSWORD PYTHONPATH="packages:apps/cli/gitmap" /Users/tr-mini/Projects/git-map/.venv/bin/python apps/cli/gitmap/main.py doctor --portal` exits 1 with missing-credentials guidance
- `PORTAL_URL=https://www.arcgis.com ARCGIS_USERNAME=paperclip_invalid_user ARCGIS_PASSWORD=paperclip_invalid_password PYTHONPATH="packages:apps/cli/gitmap" /Users/tr-mini/Projects/git-map/.venv/bin/python apps/cli/gitmap/main.py doctor --portal` exits 1 with invalid username/password
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests/test_doctor_command.py`
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests/test_release_checks.py packages/gitmap_core/tests/test_doctor_command.py`
- `/Users/tr-mini/Projects/git-map/.venv/bin/python -m pytest packages/gitmap_core/tests -v --tb=short` (`798 passed`)
- `git diff --check`

Paperclip: JIG-816