### PR TITLE
Fix post-merge CI regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-798%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-797%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 

--- a/apps/cli/gitmap/commands/diff.py
+++ b/apps/cli/gitmap/commands/diff.py
@@ -277,6 +277,9 @@ def diff(
     try:
         from gitmap_core.diff import diff_maps
 
+        if output and fmt != "html":
+            raise click.ClickException("--output can only be used with --format html.")
+
         repo = find_repository()
 
         if not repo:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -27,7 +27,7 @@ pip install click rich
 pytest packages/gitmap_core/tests -v
 ```
 
-All 798+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 797+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -35,7 +35,7 @@ All 798+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 798+ tests live here
+│       └── tests/          # 797+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 798+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 797+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **798+ tests** running in CI
+- **797+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 798+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 797+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 798+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 797+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 798+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 797+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 798+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 797+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.


### PR DESCRIPTION
## Summary
- reject `gitmap diff --output` unless `--format html` before repository lookup
- refresh public test-count claims from `798+` to `797+` to match release checks

## Testing
- `git diff --check`
- local Python test import path blocked here because bare `python3` lacks `deepdiff`; patch mirrors the failing CI assertions exactly