### PR TITLE
test: cover CLI help example formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-807%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-814%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 

--- a/apps/cli/gitmap/commands/cherry_pick.py
+++ b/apps/cli/gitmap/commands/cherry_pick.py
@@ -50,6 +50,8 @@ def cherry_pick(
     from one branch to another.
 
     Examples:
+
+    \b
         gitmap cherry-pick abc12345
         gitmap cherry-pick abc12345 -r "Backporting critical fix"
     """

--- a/apps/cli/gitmap/commands/commit.py
+++ b/apps/cli/gitmap/commands/commit.py
@@ -58,6 +58,8 @@ def commit(
     A commit message is required.
 
     Examples:
+
+    \b
         gitmap commit -m "Initial commit"
         gitmap commit -m "Added new layer" --author "John Doe"
         gitmap commit -m "Fixed symbology" -r "Client requested higher contrast"

--- a/apps/cli/gitmap/commands/init.py
+++ b/apps/cli/gitmap/commands/init.py
@@ -93,6 +93,8 @@ def init(
     (defaults to current directory).
 
     Example:
+
+    \b
         gitmap init
         gitmap init --project-name "My Project" --user-name "John Doe"
         gitmap init /path/to/project

--- a/apps/cli/gitmap/commands/merge.py
+++ b/apps/cli/gitmap/commands/merge.py
@@ -88,6 +88,8 @@ def merge(
     same layer is modified in both branches.
 
     Examples:
+
+    \b
         gitmap merge feature/new-layer
         gitmap merge main --no-commit
     """

--- a/apps/cli/gitmap/commands/push.py
+++ b/apps/cli/gitmap/commands/push.py
@@ -79,6 +79,8 @@ def push(
     Use --no-notify to skip notifications for this push.
 
     Examples:
+
+    \b
         gitmap push
         gitmap push --branch feature/new-layer
         gitmap push --url https://portal.example.com

--- a/apps/cli/gitmap/commands/revert.py
+++ b/apps/cli/gitmap/commands/revert.py
@@ -49,6 +49,8 @@ def revert(
     specified commit. Does not remove history - adds an inverse commit.
 
     Examples:
+
+    \b
         gitmap revert abc12345
         gitmap revert abc12345 -r "Reverted due to breaking changes"
     """

--- a/apps/cli/gitmap/commands/status.py
+++ b/apps/cli/gitmap/commands/status.py
@@ -49,6 +49,8 @@ def status(fmt: str) -> None:
     and a summary of modifications in the staging area.
 
     Example:
+
+    \b
         gitmap status
     """
     try:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,7 +28,7 @@ python -m pip install -e apps/cli/gitmap
 pytest packages/gitmap_core/tests -v
 ```
 
-All 807+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 814+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -36,7 +36,7 @@ All 807+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 807+ tests live here
+│       └── tests/          # 814+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 807 collected core tests, 69 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 814 collected core tests, 69 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 807 collected core tests and 69 collected integration tests.
+- Updated validation evidence to 814 collected core tests and 69 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 807+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 814+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **807+ tests** running in CI
+- **814+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 807+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 814+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 807+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 814+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 807+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 814+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 807+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 814+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/packages/gitmap_core/tests/test_cli_registration.py
+++ b/packages/gitmap_core/tests/test_cli_registration.py
@@ -289,6 +289,59 @@ class TestCommandRegistration:
                     "gitmap checkout -b feature/new-layer  # Create and checkout",
                 ],
             ),
+            (
+                "cherry-pick",
+                [
+                    "gitmap cherry-pick abc12345",
+                    'gitmap cherry-pick abc12345 -r "Backporting critical fix"',
+                ],
+            ),
+            (
+                "commit",
+                [
+                    'gitmap commit -m "Initial commit"',
+                    'gitmap commit -m "Added new layer" --author "John Doe"',
+                    'gitmap commit -m "Fixed symbology" -r "Client requested higher contrast"',
+                ],
+            ),
+            (
+                "init",
+                [
+                    "gitmap init",
+                    'gitmap init --project-name "My Project" --user-name "John Doe"',
+                    "gitmap init /path/to/project",
+                ],
+            ),
+            (
+                "merge",
+                [
+                    "gitmap merge feature/new-layer",
+                    "gitmap merge main --no-commit",
+                ],
+            ),
+            (
+                "push",
+                [
+                    "gitmap push",
+                    "gitmap push --branch feature/new-layer",
+                    "gitmap push --url https://portal.example.com",
+                    "gitmap push --no-notify  # Skip notifications even for production branch",
+                    'gitmap push -r "Deploying accessibility improvements"',
+                ],
+            ),
+            (
+                "revert",
+                [
+                    "gitmap revert abc12345",
+                    'gitmap revert abc12345 -r "Reverted due to breaking changes"',
+                ],
+            ),
+            (
+                "status",
+                [
+                    "gitmap status",
+                ],
+            ),
         ],
     )
     def test_first_user_command_examples_render_on_separate_lines(


### PR DESCRIPTION
## Summary\n- preserve separate-line rendering for additional first-user CLI help examples\n- extend CLI registration coverage for commit/init/status/merge/push/revert/cherry-pick examples\n- sync public validation evidence from 807 to 814 collected core tests\n\n## Validation\n- python3 -m pytest packages/gitmap_core/tests/test_cli_registration.py\n- python3 -m pytest\n- python3 -m ruff check touched Python files\n\nNote: repo-wide python3 -m ruff check . still reports pre-existing unrelated issues outside this change scope.