### PR TITLE
fix: harden completions packaging proof

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,14 +2,19 @@
 
 GitMap uses **PyPI Trusted Publishing** (OIDC) — no API tokens needed once configured.
 
-GitMap currently publishes two user-facing packages. The root `gitmap` PyPI name is occupied by an unrelated project, so it is not part of the active publish contract unless that name is transferred or explicitly re-approved.
+GitMap is preparing two user-facing packages. The root `gitmap` PyPI name is occupied by an unrelated project, so it is not part of the active publish contract unless that name is transferred or explicitly re-approved.
 
 | PyPI Package | Tag Pattern | Install |
 |---|---|---|
 | `gitmap-core` | `core-v*` | `pip install gitmap-core` |
-| `gitmap-cli` | `cli-v*` | `pip install gitmap-cli` |
+| `gitmap-cli` | `cli-v*` | `pip install gitmap-cli` (after first successful publish) |
 
-> **Most users want `pip install gitmap-cli`** — it installs the `gitmap` console command and depends on `gitmap-core`. Use `pip install gitmap-core` only for library/API use.
+> **Current first-user install contract:** use the source install flow in
+> `docs/getting-started/installation.md` until `gitmap-cli` is visibly
+> available on PyPI and the published install path has been re-verified for the
+> supported Python 3.11-3.14 matrix. `gitmap-core` can be published
+> independently for library/API consumers, but it does not provide the `gitmap`
+> CLI entrypoint by itself.
 
 ---
 
@@ -61,14 +66,16 @@ Before tagging, run the local release guardrails:
 
 ```bash
 python3 scripts/release_checks.py
-python3 -m build packages/gitmap_core --outdir dist/
-python3 -m build apps/cli/gitmap --outdir dist/
+python3 -m build packages/gitmap_core --outdir dist/core
+python3 -m build apps/cli/gitmap --outdir dist/cli
+python3 -m build . --outdir dist/meta
 python3 scripts/verify_dist_install.py core
 python3 scripts/verify_dist_install.py cli
+python3 scripts/verify_dist_install.py meta
 ```
 
 This verifies that the published package versions, dependency pins, project metadata, publish workflow tag patterns, and dist-install smoke tests are still aligned.
-The publish workflow now runs the same clean-venv install smoke test for `core` and `cli` before uploading artifacts to PyPI.
+The publish workflow now runs the same clean-venv install smoke test against the real `dist/core`, `dist/cli`, and `dist/meta` layout before upload checks.
 
 ### Patch release (core fix)
 
@@ -124,7 +131,12 @@ The active publishable packages should stay in sync (same version number).
 After tags are pushed and workflow runs succeed:
 
 ```bash
-pip install gitmap-cli       # CLI (installs the gitmap command and core dependency)
-pip install gitmap-core      # core library only
-gitmap --version             # should show new version
+pip index versions gitmap-cli
+pip install gitmap-cli
+gitmap --version             # should show the new version once the CLI project exists
+pip install gitmap-core      # optional library-only verification
 ```
+
+If `pip index versions gitmap-cli` reports no matching distribution, the CLI
+publish did not land on PyPI yet. Keep the public install docs on the source
+install path and treat the release as incomplete until the package is available.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gitmap-cli.svg)](https://pypi.org/project/gitmap-cli/)
 [![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://www.python.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Tests](https://img.shields.io/badge/tests-825%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
+[![Tests](https://img.shields.io/badge/tests-832%2B-brightgreen)](https://github.com/14-TR/Git-Map/actions)
 
 GitMap brings familiar Git workflows to ArcGIS Online and Portal for ArcGIS. Clone a web map, make changes in a branch, inspect exactly what changed, merge safely, and push the approved version back to Portal.
 

--- a/apps/cli/gitmap/commands/completions.py
+++ b/apps/cli/gitmap/commands/completions.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 import click
 from rich.console import Console
@@ -54,6 +55,8 @@ _GITMAP_COMPLETE=fish_source gitmap | source
 # Or run once to install permanently:
 _GITMAP_COMPLETE=fish_source gitmap > ~/.config/fish/completions/gitmap.fish""",
 }
+
+_CLI_MAIN = Path(__file__).resolve().parents[1] / "main.py"
 
 
 # ---- Completions Command ------------------------------------------------------------------------------------
@@ -121,18 +124,7 @@ def completions(
     target_shell = target_shell.lower()
 
     if print_script:
-        # Emit the raw script so the user can pipe it
-        import subprocess
-
-        env = os.environ.copy()
-        env[_COMPLETE_VAR[target_shell]] = f"{target_shell}_source"
-        result = subprocess.run(
-            [sys.executable, "-m", "gitmap_cli.main"],
-            env=env,
-            capture_output=True,
-            text=True,
-        )
-        click.echo(result.stdout, nl=False)
+        click.echo(_generate_completion_script(target_shell), nl=False)
         return
 
     if install_shell:
@@ -152,6 +144,49 @@ def completions(
     console.print()
     console.print(f"Or run [cyan]gitmap completions --install {target_shell}[/cyan] to add this automatically.")
     console.print()
+
+
+def _generate_completion_script(target_shell: str) -> str:
+    """Generate the raw completion script via the matching CLI entrypoint."""
+    import subprocess
+
+    env = os.environ.copy()
+    env[_COMPLETE_VAR[target_shell]] = f"{target_shell}_source"
+    command = _completion_command(env)
+    result = subprocess.run(command, env=env, capture_output=True, text=True, check=False)
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise click.ClickException(
+            "Failed to generate completion script"
+            + (f": {stderr}" if stderr else f" (exit {result.returncode})")
+        )
+
+    if not result.stdout:
+        stderr = (result.stderr or "").strip()
+        raise click.ClickException(
+            "Completion generator returned empty output"
+            + (f": {stderr}" if stderr else "")
+        )
+
+    return result.stdout
+
+
+def _completion_command(env: dict[str, str]) -> list[str]:
+    """Build the subprocess command for installed and source-checkout execution."""
+    if _CLI_MAIN.exists():
+        repo_root = _CLI_MAIN.parents[2]
+        pythonpath_entries = [
+            str(repo_root / "packages"),
+            str(_CLI_MAIN.parent),
+        ]
+        existing = env.get("PYTHONPATH")
+        if existing:
+            pythonpath_entries.append(existing)
+        env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+        return [sys.executable, str(_CLI_MAIN)]
+
+    return [sys.executable, "-m", "gitmap_cli.main"]
 
 
 def _detect_shell() -> str | None:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,7 +28,7 @@ python -m pip install -e apps/cli/gitmap
 pytest packages/gitmap_core/tests -v
 ```
 
-All 825+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
+All 832+ tests must pass before opening a PR. The CI pipeline runs the same suite on Python 3.11, 3.12, 3.13, and 3.14.
 
 ## Project Structure
 
@@ -36,7 +36,7 @@ All 825+ tests must pass before opening a PR. The CI pipeline runs the same suit
 Git-Map/
 ├── packages/
 │   └── gitmap_core/        # Core library — version control engine
-│       └── tests/          # 825+ tests live here
+│       └── tests/          # 832+ tests live here
 ├── apps/
 │   ├── cli/gitmap/         # `gitmap` CLI (Click + Rich)
 │   ├── mcp/                # MCP server for AI agent integration

--- a/docs/technical-paper.md
+++ b/docs/technical-paper.md
@@ -12,7 +12,7 @@
 
 ArcGIS Online and ArcGIS Enterprise web maps are mutable JSON artifacts that encode operational layers, tables, popups, renderers, basemaps, extents, and map-level configuration. In many professional GIS teams, these artifacts function as production software assets, yet they are commonly governed through manual naming conventions, cloned Portal items, screenshots, and informal change logs. GitMap addresses this governance gap by adapting distributed version control concepts to ArcGIS web map state. The system stores immutable full-map JSON snapshots in a local `.gitmap` repository, provides branch, commit, diff, merge, revert, cherry-pick, stash, tag, push, and pull workflows, and exposes map-aware review artifacts through terminal, JSON, visual, and HTML diff outputs.
 
-This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 825 collected core tests, 69 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
+This paper describes the May 2026 implementation of GitMap v0.7.0. The current public system is a Python monorepo composed of `gitmap-core`, `gitmap-cli`, integration prototypes for ArcGIS Pro and OpenClaw, and MkDocs documentation. Its central technical claim is pragmatic rather than theoretical: treating ArcGIS web map JSON as a first-class versioned artifact enables safer review and rollback workflows for map configuration changes that are not covered by geodatabase versioning. Current validation consists of 832 collected core tests, 69 collected integration tests for ArcGIS Pro/OpenClaw surfaces, CLI/package smoke coverage, documentation builds, and repository-level adoption roadmaps. The primary remaining threats to validity are limited real-user validation, dependence on ArcGIS Portal API behavior, prototype-stage integration surfaces, and the absence of a production multi-user remote service.
 
 ---
 
@@ -342,7 +342,7 @@ This update replaces stale March 2026 claims with evidence from the May 13, 2026
 - Updated project status from v0.6.0+ to v0.7.0 public alpha.
 - Updated Python support from 3.10+ to `>=3.11,<3.15`.
 - Reframed MCP/OpenClaw and ArcGIS Pro work as integration/prototype surfaces rather than primary validated adoption paths.
-- Updated validation evidence to 825 collected core tests and 69 collected integration tests.
+- Updated validation evidence to 832 collected core tests and 69 collected integration tests.
 - Added the May 2026 product focus: first-user onboarding, short demo asset, and real GIS-user validation.
 - Reorganized limitations around adoption validity, Portal API dependence, layer identity, conservative merge semantics, storage growth, path safety, and privacy.
 

--- a/marketing/blog-post.md
+++ b/marketing/blog-post.md
@@ -2,7 +2,7 @@
 
 If you've ever spent 20 minutes trying to remember why someone changed the basemap on a production web map, this post is for you.
 
-I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 825+ tests and real workflows. I want to share what I built, why, and what I learned.
+I'm a GIS developer who got frustrated enough to build **GitMap** — an open-source command-line tool that brings Git-style version control to ArcGIS Online and Enterprise Portal web maps. After about a year of development, it's now at v0.7.0 public alpha with 832+ tests and real workflows. I want to share what I built, why, and what I learned.
 
 ---
 
@@ -107,7 +107,7 @@ After 6 months of iteration, GitMap now has:
 - **Context visualization**: Mermaid flowcharts, git-graph, ASCII, HTML of your repo history
 - **ArcGIS Pro toolbox**: 9 native tools if you work in Pro
 - **MCP server**: Expose GitMap as tools for AI agents (Claude, etc.)
-- **825+ tests** running in CI
+- **832+ tests** running in CI
 - **Docker support** for team deployments
 - **CI via GitHub Actions** on Python 3.11, 3.12, 3.13, and 3.14
 
@@ -125,7 +125,7 @@ Code merges work line-by-line. JSON merges need to work property-by-property, un
 Portal/ArcGIS Online authentication has multiple modes: username/password, OAuth, IWA, PKI. Getting the connection setup to be simple enough for non-developers while supporting all the enterprise edge cases is still a work in progress.
 
 **4. Tests are your friend.**  
-Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 825+ tests made a real difference in confidence.
+Because I can't run tests against a real Portal, everything is mocked. This forced me to think carefully about interfaces and made refactoring much safer. Going from 0 to 832+ tests made a real difference in confidence.
 
 ---
 

--- a/marketing/launch-strategy.md
+++ b/marketing/launch-strategy.md
@@ -130,7 +130,7 @@ Before posting anywhere, nail the first-impression UX:
 >
 > I built GitMap — an open-source CLI that gives Git-like version control to ArcGIS web maps. You can commit snapshots, branch, diff, merge, and revert — same mental model as Git, but operating on web map JSON from Portal.
 >
-> It's at v0.7.0 public alpha with 825+ tests: https://github.com/14-TR/Git-Map
+> It's at v0.7.0 public alpha with 832+ tests: https://github.com/14-TR/Git-Map
 >
 > Would you be willing to try it on a non-critical map and give me 10 minutes of feedback? I'm specifically looking to understand what's broken or missing before a wider launch.
 >

--- a/marketing/reddit-rgis-post.md
+++ b/marketing/reddit-rgis-post.md
@@ -41,7 +41,7 @@ It stores snapshots of your web map JSON locally (in a `.gitmap/` directory), so
 - Get diff visualizations in Mermaid/git-graph/HTML
 
 **Current state:**
-- v0.7.0 public alpha, 825+ tests, Python 3.11/3.12/3.13/3.14
+- v0.7.0 public alpha, 832+ tests, Python 3.11/3.12/3.13/3.14
 - 18 Git-like commands
 - ArcGIS Pro toolbox (9 native tools)
 - MCP server for AI agent integration
@@ -82,7 +82,7 @@ GitMap works with both. Set `PORTAL_URL` to either your Enterprise instance or `
 Currently it versions the *web map item JSON* (layer references, symbology, extent, etc.) — not the underlying data. Feature service data versioning is a separate problem.
 
 **"Is it production-ready?"**
-It's v0.7.0 public alpha with 825+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
+It's v0.7.0 public alpha with 832+ tests. I use it on real projects. I'd call it "production-ready for developers" — it needs more UX polish before recommending it to non-technical GIS staff.
 
 **"Why not just use ArcGIS Versioning?"**
 ArcGIS Versioning is for geodatabase data. This is for web map *configuration* — which layers are shown, how they're symbolized, pop-up templates, extents, etc. Different problem.

--- a/packages/gitmap_core/tests/test_cli_registration.py
+++ b/packages/gitmap_core/tests/test_cli_registration.py
@@ -24,6 +24,7 @@ import sys
 import types
 from pathlib import Path
 
+import click
 import pytest
 from click.testing import CliRunner
 
@@ -494,3 +495,47 @@ class TestCommandRegistration:
         assert fish_completion.read_text(encoding="utf-8") == (
             "# gitmap shell completion\n_GITMAP_COMPLETE=fish_source gitmap | source\n"
         )
+
+    def test_completions_print_emits_script_from_source_checkout(self) -> None:
+        """The real --print path should emit a completion script in a source checkout."""
+        repo_root = Path(__file__).resolve().parents[3]
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                [
+                    str(repo_root / "packages"),
+                    str(repo_root / "apps" / "cli" / "gitmap"),
+                ]
+            ),
+        }
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(repo_root / "apps" / "cli" / "gitmap" / "main.py"),
+                "completions",
+                "--print",
+                "bash",
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr or result.stdout
+        assert result.stdout.strip()
+        assert "_gitmap_completion()" in result.stdout
+        assert "complete -o nosort -F _gitmap_completion gitmap" in result.stdout
+
+    def test_completions_print_raises_on_empty_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Silent empty completion output should surface as a user-facing error."""
+        completed = subprocess.CompletedProcess(args=["python"], returncode=0, stdout="", stderr="")
+
+        def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            return completed
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        with pytest.raises(click.ClickException, match="returned empty output"):
+            completions_module._generate_completion_script("bash")

--- a/packages/gitmap_core/tests/test_release_checks.py
+++ b/packages/gitmap_core/tests/test_release_checks.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -12,10 +13,19 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RELEASE_CHECKS_PATH = REPO_ROOT / "scripts/release_checks.py"
+VERIFY_DIST_INSTALL_PATH = REPO_ROOT / "scripts/verify_dist_install.py"
 
 
 def _load_release_checks_module():
     spec = importlib.util.spec_from_file_location("release_checks", RELEASE_CHECKS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_verify_dist_install_module():
+    spec = importlib.util.spec_from_file_location("verify_dist_install", VERIFY_DIST_INSTALL_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
@@ -52,6 +62,48 @@ def test_ci_package_validation_smoke_tests_dist_installs() -> None:
         "python scripts/verify_dist_install.py meta",
     ):
         assert expected_command in ci_workflow_text
+
+
+@pytest.mark.parametrize(
+    ("kind", "prefix", "artifact_name"),
+    [
+        ("core", "gitmap_core-", "gitmap_core-1.2.3-py3-none-any.whl"),
+        ("cli", "gitmap_cli-", "gitmap_cli-1.2.3-py3-none-any.whl"),
+        ("meta", "gitmap-", "gitmap-1.2.3-py3-none-any.whl"),
+    ],
+)
+def test_verify_dist_install_prefers_kind_specific_dist_dirs(
+    kind: str,
+    prefix: str,
+    artifact_name: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verify_dist_install = _load_verify_dist_install_module()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dist_dir = Path(tmpdir) / "dist"
+        kind_dir = dist_dir / kind
+        kind_dir.mkdir(parents=True)
+        expected_path = kind_dir / artifact_name
+        expected_path.write_text("wheel")
+        monkeypatch.setattr(verify_dist_install, "DIST_DIR", dist_dir)
+
+        assert verify_dist_install._pick_artifact(prefix) == expected_path
+
+
+def test_verify_dist_install_falls_back_to_top_level_dist(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verify_dist_install = _load_verify_dist_install_module()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dist_dir = Path(tmpdir) / "dist"
+        dist_dir.mkdir()
+        expected_path = dist_dir / "gitmap_core-1.2.3-py3-none-any.whl"
+        expected_path.write_text("wheel")
+        monkeypatch.setattr(verify_dist_install, "DIST_DIR", dist_dir)
+
+        assert verify_dist_install._pick_artifact("gitmap_core-") == expected_path
 
 
 def test_release_metadata_requires_existing_readmes_and_typed_markers() -> None:
@@ -100,6 +152,21 @@ def test_public_validation_evidence_matches_collected_core_tests() -> None:
     for relative_path, expected_text in public_claims.items():
         text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
         assert expected_text in text, f"{relative_path} missing {expected_text!r}"
+
+
+def test_install_docs_and_publishing_doc_agree_on_current_cli_install_status() -> None:
+    installation_text = (
+        REPO_ROOT / "docs/getting-started/installation.md"
+    ).read_text(encoding="utf-8")
+    publishing_text = (REPO_ROOT / "PUBLISHING.md").read_text(encoding="utf-8")
+
+    expected_warning = (
+        "The `gitmap-cli` PyPI package is not currently a supported first-user install path."
+    )
+    assert expected_warning in installation_text
+    assert "use the source install flow" in publishing_text
+    assert "`gitmap-cli` is visibly" in publishing_text
+    assert "available on PyPI" in publishing_text
 
 
 @pytest.mark.parametrize(

--- a/scripts/verify_dist_install.py
+++ b/scripts/verify_dist_install.py
@@ -41,16 +41,33 @@ def _run(command: list[str], *, env: dict[str, str] | None = None) -> None:
     subprocess.run(command, check=True, env=env)
 
 
+def _artifact_search_dirs(kind: str) -> list[Path]:
+    search_dirs = [DIST_DIR / kind, DIST_DIR]
+    return [path for path in search_dirs if path.is_dir()]
+
+
 def _pick_artifact(prefix: str) -> Path:
+    search_dirs = _artifact_search_dirs(_prefix_kind(prefix))
     matches = sorted(
-        path for path in DIST_DIR.iterdir()
+        path
+        for directory in search_dirs
+        for path in directory.iterdir()
         if path.is_file() and path.name.startswith(prefix)
     )
     if not matches:
-        raise FileNotFoundError(f"No dist artifacts found for prefix {prefix!r} in {DIST_DIR}")
+        searched = ", ".join(str(path) for path in search_dirs) or str(DIST_DIR)
+        raise FileNotFoundError(f"No dist artifacts found for prefix {prefix!r} in {searched}")
 
     wheels = [path for path in matches if path.suffix == ".whl"]
     return wheels[0] if wheels else matches[0]
+
+
+def _prefix_kind(prefix: str) -> str:
+    if prefix == "gitmap-":
+        return "meta"
+    if prefix == "gitmap_cli-":
+        return "cli"
+    return "core"
 
 
 def verify(kind: str) -> None:


### PR DESCRIPTION
## Summary
- fix `gitmap completions --print <shell>` for source-checkout execution and fail loudly on empty output
- align dist-install verification with the real `dist/core`, `dist/cli`, and `dist/meta` build layout
- update publishing/install/public-proof docs so they match the current `832`-test and PyPI support contract

## Testing
- python3 -m pytest -q packages/gitmap_core/tests/test_cli_registration.py packages/gitmap_core/tests/test_release_checks.py
- PYTHONPATH=/Users/tr-mini/Projects/git-map/packages:/Users/tr-mini/Projects/git-map/apps/cli/gitmap python3 apps/cli/gitmap/main.py completions --print bash | head -n 2
- python3 scripts/verify_dist_install.py meta
- git diff --check